### PR TITLE
stop auto reconnecting when stream is intentionally disconnected.

### DIFF
--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -85,6 +85,12 @@ class EventStream extends EventEmitter {
 	}
 
 	end() {
+		if (!this.req) {
+			// request was ended intentionally by abort
+			// do not auto reconnect.
+			return;
+		}
+
 		this.req = undefined;
 		setTimeout(() => {
 			this.connect().catch(err => {


### PR DESCRIPTION
calling abort on a connected EventStream causes the 'end' event on the response to fire, which is hooked to the 'end' method of the EventStream. So prior to this change, the stream would auto reconnect after an abort, which seems contrary to user expectations, since they just called abort on the stream. Adding this check prevents the reconnect logic from firing when the event stream has been intentionally ended.