### PR TITLE
Catch event handler error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,19 @@
 language: node_js
 node_js:
 - 4
-- 5
 - 6
-- 7
 - 8
+- 10
 matrix:
   include:
-  - node_js: 6
+  - node_js: 8
     env: TEST_SUITE=browser
 cache:
   directories:
   - node_modules
 sudo: false
 install:
-- npm -g install npm@latest
+- npm -g install npm@5.10
 - npm install
 - npm prune
 script: "./travis_tests.sh"

--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -73,8 +73,6 @@ class EventStream extends EventEmitter {
 
 				this.data = '';
 				this.buf = '';
-				this.eventName;
-				this.lastEventId;
 
 				res.on('data', this.parse.bind(this));
 				res.once('end', this.end.bind(this));
@@ -162,7 +160,6 @@ class EventStream extends EventEmitter {
 					const event = JSON.parse(this.data);
 					event.name = this.eventName || '';
 					try {
-
 						if (this.eventName !== 'event') {
 							this.emit(this.eventName, event);
 						}
@@ -170,12 +167,13 @@ class EventStream extends EventEmitter {
 					} catch (error) {
 						this.emit('error', error);
 					}
-					this.data = '';
 				}
-				this.eventName = undefined;
-				this.event = false;
 			} catch (e) {
 				// do nothing if JSON.parse fails
+			} finally {
+				this.data = '';
+				this.eventName = undefined;
+				this.event = false;
 			}
 		} else if (fieldLength > 0) {
 			const field = this.buf.slice(pos, pos + fieldLength);

--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -160,7 +160,7 @@ class EventStream extends EventEmitter {
 					const event = JSON.parse(this.data);
 					event.name = this.eventName || '';
 					try {
-						if (this.eventName !== 'event') {
+						if (['event', 'error', 'response'].indexOf(this.eventName) === -1) {
 							this.emit(this.eventName, event);
 						}
 						this.emit('event', event);

--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -51,10 +51,15 @@ class EventStream extends EventEmitter {
 							// don't bother doing anything special if the JSON.parse fails
 							// since we are already about to reject the promise anyway
 						} finally {
-							this.emit('response', {
-								statusCode,
-								body
-							});
+							try {
+								this.emit('response', {
+									statusCode,
+									body
+								});
+							} catch (error) {
+								this.emit('error', error);
+							}
+
 							let errorDescription = `HTTP error ${statusCode} from ${this.uri}`;
 							if (body && body.error_description) {
 								errorDescription += ' - ' + body.error_description;
@@ -156,10 +161,15 @@ class EventStream extends EventEmitter {
 				if (this.data.length > 0 && this.event) {
 					const event = JSON.parse(this.data);
 					event.name = this.eventName || '';
-					if (this.eventName !== 'event') {
-						this.emit(this.eventName, event);
+					try {
+
+						if (this.eventName !== 'event') {
+							this.emit(this.eventName, event);
+						}
+						this.emit('event', event);
+					} catch (error) {
+						this.emit('error', error);
 					}
-					this.emit('event', event);
 					this.data = '';
 				}
 				this.eventName = undefined;


### PR DESCRIPTION
The [SSE stream](https://www.w3.org/TR/2009/WD-eventsource-20090421/) parser does not handle errors well. If a user event handler throws an exception, the error will be silently ignored and the parser will stop parsing future events. Parsing errors in the JSON data will also be silently ignored and the parser will stop parsing future events.

TODO: there parser has no tests. We should add `EventStream.spec.js` to test the implementation.

Fixes #15 and fixes #62