### PR TITLE
Remove unused parameter `stripeToken` in `setUserInfo` method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -830,7 +830,6 @@ Set details on the current user
 **Parameters**
 
 -   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Options for this API call
-    -   `options.stripeToken` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Set user's stripe token for payment
     -   `options.accountInfo` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Set user's extended info fields (name, business account, company name, etc)
     -   `options.auth` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Access Token
     -   `options.context`  

--- a/src/Particle.js
+++ b/src/Particle.js
@@ -735,15 +735,13 @@ class Particle {
 	 * Set details on the current user
 	 * @param  {Object} options Options for this API call
 	 * @param  {String} options.auth Access Token
-	 * @param  {String} options.stripeToken Set user's stripe token for payment
 	 * @param  {String} options.accountInfo Set user's extended info fields (name, business account, company name, etc)
 	 * @return {Promise}
 	 */
-	setUserInfo({ stripeToken, accountInfo, auth, context }) {
-		const bodyObj = {};
-
-		(stripeToken ? bodyObj.stripe_token = stripeToken : null);
-		(accountInfo ? bodyObj.account_info = accountInfo : null);
+	setUserInfo({ accountInfo, auth, context }) {
+		const bodyObj = {
+			account_info: accountInfo
+		};
 
 		return this.put('/v1/user', bodyObj, auth, context);
 	}

--- a/test/Particle.spec.js
+++ b/test/Particle.spec.js
@@ -1074,14 +1074,13 @@ describe('ParticleAPI', () => {
 		});
 		describe('.setUserInfo', () => {
 			it('generates request', () => {
-				return api.setUserInfo({ auth: 'X', stripeToken: '123ABCD', accountInfo: {first_name: 'John', last_name: 'Scully'} }).then((results) => {
+				return api.setUserInfo({ auth: 'X', accountInfo: {first_name: 'John', last_name: 'Scully'} }).then((results) => {
 					results.should.eql({
 						method: 'put',
 						uri: '/v1/user',
 						auth: 'X',
 						context: {},
 						data: {
-							stripe_token: '123ABCD',
 							account_info: {first_name: 'John', last_name: 'Scully'}
 						}
 					});


### PR DESCRIPTION
[Here](https://github.com/particle-iot/api-service/blob/4fd5d7f9a4472b89a6a5b3f49bc09835f600cd69/test/lib/userViews.spec.js#L312) it says:
> does not accept a stripe token, as all Stripe logic now lives in the billing API

Also, `setUserInfo` method is used only in Login app and it is not sending from there.