### PR TITLE
Remove v4 build step for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-- 4
 - 6
 - 8
 - 10


### PR DESCRIPTION
According to the [Node.js LTS schedule](https://github.com/nodejs/Release#release-schedule) Node v4's maintenance period ended March 31st, 2018. We should be safe to remove the checks from the build process.