### PR TITLE
Add support to flash a product device with firmware

### DIFF
--- a/src/Particle.js
+++ b/src/Particle.js
@@ -492,20 +492,21 @@ class Particle {
 	 * Compile and flash application firmware to a device. Pass a pre-compiled binary to flash it directly to the device.
 	 * @param  {Object} options Options for this API call
 	 * @param  {String} options.deviceId      Device ID or Name
+	 * @param  {String} options.product       Flash device in this product ID or slug
 	 * @param  {Object} options.files         Object containing files to be compiled and flashed. Keys should be the filenames, including relative path, and the values should be a path or Buffer of the file contents in Node, or a File or Blob in the browser.
 	 * @param  {String} [options.targetVersion=latest] System firmware version to compile against
 	 * @param  {String} options.auth          String
 	 * @return {Promise}
 	 */
-	flashDevice({ deviceId, files, targetVersion, auth, context }) {
+	flashDevice({ deviceId, product, files, targetVersion, auth, context }) {
+		const uri = this.deviceUri({ deviceId, product });
 		const form = {};
 		if (targetVersion) {
 			form.build_target_version = targetVersion;
 		} else {
 			form.latest = 'true';
 		}
-		return this.request({ uri: `/v1/devices/${deviceId}`,
-			files, auth, form, context, method: 'put' });
+		return this.request({ uri, files, auth, form, context, method: 'put' });
 	}
 
 	/**

--- a/test/Particle.spec.js
+++ b/test/Particle.spec.js
@@ -659,15 +659,28 @@ describe('ParticleAPI', () => {
 			});
 		});
 		describe('.flashDevice', () => {
-			it('generates request', () => {
-				return api.flashDevice(props).then(Common.expectDeviceUrlAndToken);
+			describe('user scope', () => {
+				it('generates request', () => {
+					return api.flashDevice(props).then(Common.expectDeviceUrlAndToken);
+				});
+				it('sends proper data', () => {
+					return api.flashDevice(props).then(({ files, form }) => {
+						form.should.be.instanceOf(Object);
+						files.should.be.instanceOf(Object);
+						files.should.have.property('app.ino').and.be.ok;
+						form.build_target_version.should.equal(props.targetVersion);
+					});
+				});
 			});
-			it('sends proper data', () => {
-				return api.flashDevice(props).then(({ files, form }) => {
-					form.should.be.instanceOf(Object);
-					files.should.be.instanceOf(Object);
-					files.should.have.property('app.ino').and.be.ok;
-					form.build_target_version.should.equal(props.targetVersion);
+			describe('product scope', () => {
+				it('generates request', () => {
+					return api.flashDevice(propsWithProduct).then((results) => {
+						results.should.match({
+							method: 'put',
+							uri: `/v1/products/${product}/devices/${props.deviceId}`,
+							auth: props.auth
+						});
+					});
 				});
 			});
 		});


### PR DESCRIPTION
I was writing a script to flash product devices and found that our API wrapper didn't support the product flash endpoint. 

Manual test:
```
var Particle = require("particle-api-js");
var particle = new Particle();
var auth = "xyz";
var product = "8178";
var file = '/home/monkbroc/Downloads/bootloader-1.0.0-electron.bin';

particle.flashDevice({ deviceId: '123456', product, files: { file }, auth })
	.then(results => {
		console.log(results.body);
	});
```