### PR TITLE
`EventStream` doesn't handle dropped connections

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,9 @@
 		"es6": true,
 		"shared-node-browser": true
 	},
+	"globals": {
+		"navigator": "readonly"
+	},
 	"rules": {
 		"no-var": 2,
 		"valid-jsdoc": [2, {

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/Release
 node_modules
 lib/
 /.idea
+*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,58 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/commons": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.1.tgz",
+      "integrity": "sha512-rgmZk5CrBGAMATk0HlHOFvo8V44/r+On6cKS80tqid0Eljd+fFBWBOXZp9H2/EB3faxdNdzXTx6QZIKLkbJ7mA==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+          "dev": true
+        }
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.0.tgz",
+      "integrity": "sha512-hskkZG4qB0HgsxrPUlnk2EiIyBwntM+ETIxCha/gidl172MCfdosNezB5706ciS5P2VhueM7MoACWwMc4A4gMQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.2.0.tgz",
+      "integrity": "sha512-j5F1rScewLtx6pbTK0UAjA3jJj4RYiSKOix53YWv+Jzy/AZ69qHxUpU8fwVLjyKbEEud9QrLpv6Ggs7WqTimYw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "JSONStream": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
@@ -192,6 +244,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-iterate": {
@@ -1629,7 +1687,7 @@
         "shasum": "1.0.2",
         "shell-quote": "1.6.1",
         "stream-browserify": "2.0.1",
-        "stream-http": "https://github.com/particle-iot/stream-http/archive/v2.2.1.tar.gz",
+        "stream-http": "^2.0.0",
         "string_decoder": "0.10.31",
         "subarg": "1.0.0",
         "syntax-error": "1.3.0",
@@ -1970,6 +2028,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "^1.0.0",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -2366,8 +2425,8 @@
       "integrity": "sha1-4gMXIMzJV12M+jH1wUbnYqgMBTQ=",
       "dev": true,
       "requires": {
-        "object.omit": "2.0.1",
-        "unique-concat": "0.2.2"
+        "object.omit": "~2.0.0",
+        "unique-concat": "~0.2.2"
       }
     },
     "cryptiles": {
@@ -3785,15 +3844,6 @@
         "mime-types": "2.1.17"
       }
     },
-    "formatio": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
-      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-      "dev": true,
-      "requires": {
-        "samsam": "1.1.2"
-      }
-    },
     "formidable": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
@@ -3819,6 +3869,535 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true
+        }
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -5275,6 +5854,12 @@
         }
       }
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "karma": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/karma/-/karma-1.7.1.tgz",
@@ -5711,9 +6296,9 @@
       }
     },
     "lolex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.1.0.tgz",
+      "integrity": "sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==",
       "dev": true
     },
     "longest": {
@@ -6286,6 +6871,13 @@
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
+    "nan": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+      "dev": true,
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.3.tgz",
@@ -6336,6 +6928,27 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
+    },
+    "nise": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.10.tgz",
+      "integrity": "sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "dev": true
+        }
+      }
     },
     "nopt": {
       "version": "3.0.6",
@@ -6822,6 +7435,23 @@
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "2.0.0",
@@ -7519,12 +8149,6 @@
       "integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
       "dev": true
     },
-    "samsam": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
-      "dev": true
-    },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
@@ -7677,15 +8301,41 @@
       "dev": true
     },
     "sinon": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
-      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.5.tgz",
+      "integrity": "sha512-1c2KK6g5NQr9XNYCEcUbeFtBpKZD1FXEw0VX7gNhWUBtkchguT2lNdS7XmS7y64OpQWfSNeeV/f8py3NNcQ63Q==",
       "dev": true,
       "requires": {
-        "formatio": "1.1.1",
-        "lolex": "1.3.2",
-        "samsam": "1.1.2",
-        "util": "0.10.3"
+        "@sinonjs/commons": "^1.3.0",
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/samsam": "^3.2.0",
+        "diff": "^3.5.0",
+        "lolex": "^3.1.0",
+        "nise": "^1.4.10",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "sinon-as-promised": {
@@ -7694,14 +8344,14 @@
       "integrity": "sha1-wFRbFoX9gTWIpO1pcBJIftEdFRs=",
       "dev": true,
       "requires": {
-        "create-thenable": "1.0.2",
-        "native-promise-only": "0.8.1"
+        "create-thenable": "~1.0.0",
+        "native-promise-only": "~0.8.1"
       }
     },
     "sinon-chai": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.13.0.tgz",
-      "integrity": "sha512-hRNu/TlYEp4Rw5IbzO8ykGoZMSG489PGUx1rvePpHGrtl20cXivRBgtr/EWYxIwL9EOO9+on04nd9k3tW8tVww==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.3.0.tgz",
+      "integrity": "sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==",
       "dev": true
     },
     "slash": {
@@ -9400,7 +10050,7 @@
             "shasum": "1.0.2",
             "shell-quote": "1.6.1",
             "stream-browserify": "2.0.1",
-            "stream-http": "https://github.com/particle-iot/stream-http/archive/v2.2.1.tar.gz",
+            "stream-http": "^2.0.0",
             "string_decoder": "1.0.3",
             "subarg": "1.0.0",
             "syntax-error": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -68,9 +68,9 @@
     "minifyify": "^7.3.1",
     "mocha": "^2.5.1",
     "should": "^9.0.0",
-    "sinon": "^1.17.4",
-    "sinon-as-promised": "^4.0.2",
-    "sinon-chai": "^2.8.0",
+    "sinon": "^7.2.5",
+    "sinon-as-promised": "^4.0.3",
+    "sinon-chai": "^3.3.0",
     "watchify": "^3.7.0"
   },
   "dependencies": {

--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -10,6 +10,8 @@ class EventStream extends EventEmitter {
 		this.uri = uri;
 		this.token = token;
 		this.reconnectInterval = 2000;
+		this.data = '';
+		this.buf = '';
 		Object.assign(this, options);
 	}
 
@@ -23,9 +25,9 @@ class EventStream extends EventEmitter {
 			const req = requestor.request({
 				hostname,
 				protocol,
-				path: `${path}?history_limit=30&access_token=${this.token}`,
+				path: `${path}?access_token=${this.token}`,
 				method: 'get',
-				port: port || (isSecure ? 443 : 80),
+				port: parseInt(port, 10) || (isSecure ? 443 : 80),
 				avoidFetch: true,
 				mode: 'prefer-streaming'
 			});
@@ -193,13 +195,6 @@ class EventStream extends EventEmitter {
 			} else if (field === 'event') {
 				this.eventName = value;
 				this.event = true;
-			} else if (field === 'id') {
-				this.lastEventId = value;
-			} else if (field === 'retry') {
-				const retry = parseInt(value, 10);
-				if (!Number.isNaN(retry)) {
-					this.reconnectInterval = retry;
-				}
 			}
 		}
 	}

--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -52,11 +52,6 @@ class EventStream extends EventEmitter {
 							// don't bother doing anything special if the JSON.parse fails
 							// since we are already about to reject the promise anyway
 						} finally {
-							this.emitSafe('response', {
-								statusCode,
-								body
-							});
-
 							let errorDescription = `HTTP error ${statusCode} from ${this.uri}`;
 							if (body && body.error_description) {
 								errorDescription += ' - ' + body.error_description;
@@ -114,7 +109,9 @@ class EventStream extends EventEmitter {
 	reconnect() {
 		setTimeout(() => {
 			this.emitSafe('reconnect');
-			this.connect().catch(err => {
+			this.connect().then(() => {
+				this.emitSafe('reconnect-success');
+			}).catch(err => {
 				this.emitSafe('reconnect-error', err);
 				this.reconnect();
 			});

--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -130,6 +130,11 @@ class EventStream extends EventEmitter {
 
 	reconnect() {
 		setTimeout(() => {
+			if (this.isOffline()) {
+				this.reconnect();
+				return;
+			}
+
 			this.emitSafe('reconnect');
 			this.connect().then(() => {
 				this.emitSafe('reconnect-success');
@@ -138,6 +143,13 @@ class EventStream extends EventEmitter {
 				this.reconnect();
 			});
 		}, this.reconnectInterval);
+	}
+
+	isOffline() {
+		if (typeof navigator === 'undefined' || navigator.hasOwnProperty('onLine')) {
+			return false;
+		}
+		return !navigator.onLine;
 	}
 
 	startIdleTimeout() {

--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -39,8 +39,16 @@ class EventStream extends EventEmitter {
 			this.req = req;
 
 			let connected = false;
+			let connectionTimeout = setTimeout(() => {
+				if (this.req) {
+					this.req.abort();
+				}
+				reject({ error: new Error('Timeout'), errorDescription: `Timeout connecting to ${this.uri}` });
+			}, this.timeout);
 
 			req.on('error', e => {
+				clearTimeout(connectionTimeout);
+
 				if (connected) {
 					this.end();
 				} else {
@@ -49,6 +57,8 @@ class EventStream extends EventEmitter {
 			});
 
 			req.on('response', res => {
+				clearTimeout(connectionTimeout);
+
 				const statusCode = res.statusCode;
 				if (statusCode !== 200) {
 					let body = '';

--- a/src/Particle.js
+++ b/src/Particle.js
@@ -559,9 +559,6 @@ class Particle {
 		const req = request('get', uri);
 		req.use(this.prefix);
 		this.headers(req, auth);
-		if (this.debug) {
-			this.debug(req);
-		}
 		return req;
 	}
 
@@ -610,7 +607,7 @@ class Particle {
 	 * @param  {String} [options.product] Events for this product ID or slug
 	 * @param  {String} options.auth     Access Token
 	 * @return {Promise} If the promise resolves, the resolution value will be an EventStream object that will
-	 * emit 'event' events, as well as the specific named event.
+	 * emit 'event' events.
 	 */
 	getEventStream({ deviceId, name, org, product, auth, context }) {
 		let uri = '/v1/';
@@ -635,7 +632,7 @@ class Particle {
 			uri += `/${encodeURIComponent(name)}`;
 		}
 
-		return new EventStream(`${this.baseUrl}${uri}`, auth, { debug: this.debug }).connect();
+		return new EventStream(`${this.baseUrl}${uri}`, auth).connect();
 	}
 
 	/**
@@ -1264,9 +1261,6 @@ class Particle {
 		const req = request('get', uri);
 		req.use(this.prefix);
 		this.headers(req, auth);
-		if (this.debug) {
-			this.debug(req);
-		}
 		return req;
 	}
 

--- a/test/EventStream-e2e-browser.html
+++ b/test/EventStream-e2e-browser.html
@@ -1,0 +1,40 @@
+<!--
+End-to-end test program for the event stream in the browser
+
+Steps:
+- npm run compile
+- npm run build
+- Replace the path to particle.min.js
+- Replace your access token in `auth`
+- Open this file in the browser
+- Follow the scenarios in EventStream.feature
+
+-->
+
+<html>
+<body>
+<p>Open the Javascript Console</p>
+<script type="text/javascript" src="file:///home/user/path/to/particle-api-js/dist/particle.min.js"></script>
+<script type="text/javascript">
+
+
+const baseUrl = 'http://localhost:9090';
+const auth = '<my-token>';
+const particle = new Particle({ baseUrl });
+
+particle.getEventStream({ deviceId: 'mine', auth }).then(stream => {
+	console.log('event stream connected');
+
+	['event', 'error', 'disconnect', 'reconnect', 'reconnect-success', 'reconnect-error'].forEach(eventName => {
+		stream.on(eventName, (arg) => {
+			console.log(eventName, arg);
+		});
+	});
+
+}).catch(function (err) {
+	console.log(err);
+});
+
+</script>
+</body>
+</html>

--- a/test/EventStream-e2e-node.js
+++ b/test/EventStream-e2e-node.js
@@ -1,0 +1,29 @@
+/*
+
+End-to-end test program for the event stream with Node
+
+Steps:
+- npm run compile
+- PARTICLE_API_TOKEN=<my-token> node test/EventStream-e2e-node.js
+- Follow the scenarios in EventStream.feature
+
+ */
+
+const Particle = require('../lib/Particle');
+
+const baseUrl = process.env.PARTICLE_API_BASE_URL || 'http://localhost:9090';
+const auth = process.env.PARTICLE_API_TOKEN;
+
+const particle = new Particle({ baseUrl });
+
+particle.getEventStream({ deviceId: 'mine', auth }).then(stream => {
+	console.log('event stream connected');
+
+	['event', 'error', 'disconnect', 'reconnect', 'reconnect-success', 'reconnect-error'].forEach(eventName => {
+		stream.on(eventName, (arg) => {
+			console.log(eventName, arg);
+		});
+	});
+}).catch(function (err) {
+	console.error(err);
+});

--- a/test/EventStream.feature
+++ b/test/EventStream.feature
@@ -1,0 +1,65 @@
+# End-to-end tests for the EventStream feature
+# These tests are hard to automate, especially in the browser since they involve error handling with the API
+# so the tests are documented in Gerkin format and are meant to be executed manually
+Feature: EventStream
+
+  Scenario: Connect to event stream
+    Given the API is running
+    And the API access token is valid
+    When I run the end-to-end test program
+    Then the output should contain "event stream connected"
+
+  Scenario: Receive event
+    Given the event stream is connected
+    When I publish a Particle event through the CLI with `particle publish test`
+    Then the event "event" with data "{ name: 'test', ... }" should be output
+
+  Scenario: Initial connection failure
+    Given the API is not running
+    When I run the end-to-end test program
+    Then the output should contain "Error: connect ECONNREFUSED"
+    And the end-to-end test program should exit
+
+  Scenario: Invalid credentials
+    Given the API is running
+    And the API access token is not valid
+    When I run the end-to-end test program
+    Then the output should contain "The access token provided is invalid"
+    And the end-to-end test program should exit
+
+  Scenario: Initial connection timeout
+    Given the API is paused (press Ctrl-Z in the API terminal)
+    When I run the end-to-end test program
+    Then the output should contain "Timeout"
+    And the end-to-end test program should exit
+
+  Scenario: Disconnect due to connection failure
+    Given the event stream is connected
+    When I stop the API (press Ctrl-C in the API terminal)
+    Then the event "disconnect" should be output immediately
+    And after 2 seconds, the event "reconnect" should be output
+    And the event "reconnect-error" should be output immediately
+    And the "reconnect" and "reconnect-error" should repeat indefinitely
+
+  Scenario: Reconnect after connection failure
+    Given the event stream is trying to reconnect after connection failure
+    When I start the API
+    Then the event "reconnect" followed by "reconnect-success" should be output
+
+  Scenario: Disconnect due to idle timeout
+    Given the event stream is connected
+    When I pause the API (press Ctrl-Z in the API terminal)
+    Then after up to 13 seconds, the event "disconnect" should be output
+    And after 2 seconds, the event "reconnect" should be output
+    And after 13 seconds, the event "reconnect-error" should be output
+    And the "reconnect" and "reconnect-error" should repeat indefinitely
+
+  Scenario: Reconnect after idle timeout
+    Given the event stream is trying to reconnect after idle timeout
+    When I unpause the API (type % in bash to resume the process)
+    Then the event "reconnect-success" should be output
+
+  Scenario: Receive event after reconnect
+    Given the event stream reconnected after a connection failure
+    When I publish a Particle event through the CLI with `particle publish test`
+    Then the event "event" should be published once

--- a/test/EventStream.spec.js
+++ b/test/EventStream.spec.js
@@ -1,0 +1,281 @@
+import { sinon, expect } from './test-setup';
+import http from 'http';
+import { EventEmitter } from 'events';
+
+import EventStream from '../src/EventStream';
+
+describe('EventStream', () => {
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	function makeRequest() {
+		const fakeRequest = new EventEmitter();
+		fakeRequest.end = sinon.spy();
+		return fakeRequest;
+	}
+
+	function makeResponse(statusCode) {
+		const fakeResponse = new EventEmitter();
+		fakeResponse.statusCode = statusCode;
+		return fakeResponse;
+	}
+
+	describe('constructor', () => {
+		it('creates an EventStream objects', () => {
+			const eventStream = new EventStream('uri', 'token');
+
+			expect(eventStream).to.be.obj;
+		});
+	});
+
+	describe('connect', () => {
+		it('successfully connects to http', () => {
+			const fakeRequest = makeRequest();
+			sinon.stub(http, 'request').callsFake(() => {
+				setImmediate(() => {
+					const fakeResponse = makeResponse(200);
+					fakeRequest.emit('response', fakeResponse);
+				});
+
+				return fakeRequest;
+			});
+
+			const eventStream = new EventStream('http://hostname:8080/path', 'token');
+
+			return eventStream.connect().then(() => {
+				expect(http.request).to.have.been.calledWith({
+					hostname: 'hostname',
+					protocol: 'http:',
+					path: '/path?access_token=token',
+					method: 'get',
+					port: 8080,
+					avoidFetch: true,
+					mode: 'prefer-streaming'
+				});
+			});
+		});
+
+		it('returns http errors on connect', () => {
+			const fakeRequest = makeRequest();
+			sinon.stub(http, 'request').callsFake(() => {
+				setImmediate(() => {
+					const fakeResponse = makeResponse(500);
+					fakeRequest.emit('response', fakeResponse);
+					setImmediate(() => {
+						fakeResponse.emit('data', '{"error":"unknown"}');
+						fakeResponse.emit('end');
+					});
+				});
+
+				return fakeRequest;
+			});
+
+			const eventStream = new EventStream('http://hostname:8080/path', 'token');
+
+			return eventStream.connect().then(() => {
+				throw new Error('expected to throw error');
+			}, (reason) => {
+				expect(reason).to.eql({
+					statusCode: 500,
+					errorDescription: 'HTTP error 500 from http://hostname:8080/path',
+					body: {
+						error: 'unknown'
+					}
+				});
+			});
+		});
+	});
+
+	describe('parse', () => {
+		let eventStream;
+		beforeEach(() => {
+			eventStream = new EventStream();
+			sinon.stub(eventStream, 'parseEventStreamLine');
+		});
+
+		it('accumulates date into the buffer before parsing line', () => {
+			eventStream.parse('wo');
+			eventStream.parse('rd');
+
+			expect(eventStream.buf).to.eql('word');
+			expect(eventStream.parseEventStreamLine).not.to.have.been.called;
+		});
+
+		it('parses a line ending with \\n', () => {
+			const line = 'field: value\n';
+
+			eventStream.parse(line);
+
+			expect(eventStream.parseEventStreamLine).to.have.been.calledWith(0, line.indexOf(':'), line.indexOf('\n'));
+		});
+
+		it('parses 2 lines ending with \\n', () => {
+			const line1 = 'field: value\n';
+			const line2 = 'field2: value2\n';
+
+			eventStream.parse(line1 + line2);
+
+			expect(eventStream.parseEventStreamLine).to.have.been.calledWith(0, line1.indexOf(':'), line1.indexOf('\n'));
+			expect(eventStream.parseEventStreamLine).to.have.been.calledWith(line1.length, line2.indexOf(':'), line2.indexOf('\n'));
+		});
+
+
+		it('parses a line ending with \\r\\n', () => {
+			const line = 'field: value\r\n';
+
+			eventStream.parse(line);
+
+			expect(eventStream.parseEventStreamLine).to.have.been.calledWith(0, line.indexOf(':'), line.indexOf('\r'));
+		});
+
+		it('parses 2 lines ending with \\r\\n', () => {
+			const line1 = 'field: value\r\n';
+			const line2 = 'field2: value2\r\n';
+
+			eventStream.parse(line1 + line2);
+
+			expect(eventStream.parseEventStreamLine).to.have.been.calledWith(0, line1.indexOf(':'), line1.indexOf('\r'));
+			expect(eventStream.parseEventStreamLine).to.have.been.calledWith(line1.length, line2.indexOf(':'), line2.indexOf('\r'));
+		});
+
+		it('clears buffer after parsing full lines', () => {
+			eventStream.parse('field: value\n');
+
+			expect(eventStream.buf).to.eql('');
+		});
+
+		it('keeps partial lines in buffer after parsing full lines', () => {
+			eventStream.parse('field: value\nfield2');
+
+			expect(eventStream.buf).to.eql('field2');
+		});
+	});
+
+	describe('parseEventStreamLine', () => {
+		let eventStream;
+		beforeEach(() => {
+			eventStream = new EventStream();
+		});
+
+		it('ignores comments', () => {
+			// comments starts with : at column 0
+			const line = ':ok\n';
+			eventStream.buf = line;
+
+			eventStream.parseEventStreamLine(0, line.indexOf(':'), line.indexOf('\n'));
+
+			expect(eventStream.event).not.to.be.ok;
+			expect(eventStream.data).to.be.eql('');
+		});
+
+		it('saves event name', () => {
+			const line = 'event: testevent\n';
+			eventStream.buf = line;
+
+			eventStream.parseEventStreamLine(0, line.indexOf(':'), line.indexOf('\n'));
+
+			expect(eventStream.event).to.be.true;
+			expect(eventStream.eventName).to.eql('testevent');
+		});
+
+		it('saves event data', () => {
+			const line = 'data: {"data":"test"}\n';
+			eventStream.buf = line;
+
+			eventStream.parseEventStreamLine(0, line.indexOf(':'), line.indexOf('\n'));
+
+			expect(eventStream.data).to.eql('{"data":"test"}\n');
+		});
+
+		it('saves event name and data on separate lines', () => {
+			const lines = ['event: testevent\n', 'data: {"data":"test"}\n'];
+			for (let line of lines) {
+				eventStream.buf = line;
+
+				eventStream.parseEventStreamLine(0, line.indexOf(':'), line.indexOf('\n'));
+			}
+
+			expect(eventStream.event).to.be.true;
+			expect(eventStream.eventName).to.eql('testevent');
+			expect(eventStream.data).to.eql('{"data":"test"}\n');
+		});
+
+		it('emits event on blank line after saving event name and data', () => {
+			const handler = sinon.spy();
+			eventStream.event = true;
+			eventStream.eventName = 'testevent';
+			eventStream.data = '{"data":"test"}\n';
+			eventStream.on('event', handler);
+
+			eventStream.parseEventStreamLine(0, -1, 0);
+
+			expect(handler).to.have.been.calledWith({
+				name: 'testevent',
+				data: 'test'
+			});
+		});
+
+		it('emits event by Particle event name', () => {
+			const handler = sinon.spy();
+			eventStream.event = true;
+			eventStream.eventName = 'myparticleevent';
+			eventStream.data = '{"data":"test"}\n';
+			eventStream.on('myparticleevent', handler);
+
+			eventStream.parseEventStreamLine(0, -1, 0);
+
+			expect(handler).to.have.been.called;
+		});
+
+		it('does not emits event by Particle event name for reserved names', () => {
+			const handler = sinon.spy();
+			eventStream.event = true;
+			eventStream.eventName = 'response';
+			eventStream.data = '{"data":"test"}\n';
+			eventStream.on('response', handler);
+
+			eventStream.parseEventStreamLine(0, -1, 0);
+
+			expect(handler).not.to.have.been.called;
+		});
+
+		it('emits error if the event handler crashes', () => {
+			const errorHandler = sinon.spy();
+			eventStream.event = true;
+			eventStream.eventName = 'testevent';
+			eventStream.data = '{"data":"test"}\n';
+			eventStream.on('error', errorHandler);
+			eventStream.on('event', () => {
+				throw new Error('failed!');
+			});
+
+			eventStream.parseEventStreamLine(0, -1, 0);
+
+			expect(errorHandler).to.have.been.called;
+		});
+
+		it('clears the event after emitting it', () => {
+			eventStream.event = true;
+			eventStream.eventName = 'testevent';
+			eventStream.data = '{"data":"test"}\n';
+
+			eventStream.parseEventStreamLine(0, -1, 0);
+
+			expect(eventStream.event).to.be.false;
+			expect(eventStream.eventName).to.be.undefined;
+			expect(eventStream.data).to.eql('');
+		});
+
+		it('ignores multiple blank lines in succession', () => {
+			const handler = sinon.spy();
+			eventStream.on('event', handler);
+
+			eventStream.parseEventStreamLine(0, -1, 0);
+			eventStream.parseEventStreamLine(0, -1, 0);
+			eventStream.parseEventStreamLine(0, -1, 0);
+
+			expect(handler).not.to.have.been.called;
+		});
+	});
+});

--- a/test/EventStream.spec.js
+++ b/test/EventStream.spec.js
@@ -12,6 +12,7 @@ describe('EventStream', () => {
 	function makeRequest() {
 		const fakeRequest = new EventEmitter();
 		fakeRequest.end = sinon.spy();
+		fakeRequest.setTimeout = sinon.spy();
 		return fakeRequest;
 	}
 

--- a/test/EventStream.spec.js
+++ b/test/EventStream.spec.js
@@ -217,30 +217,6 @@ describe('EventStream', () => {
 			});
 		});
 
-		it('emits event by Particle event name', () => {
-			const handler = sinon.spy();
-			eventStream.event = true;
-			eventStream.eventName = 'myparticleevent';
-			eventStream.data = '{"data":"test"}\n';
-			eventStream.on('myparticleevent', handler);
-
-			eventStream.parseEventStreamLine(0, -1, 0);
-
-			expect(handler).to.have.been.called;
-		});
-
-		it('does not emits event by Particle event name for reserved names', () => {
-			const handler = sinon.spy();
-			eventStream.event = true;
-			eventStream.eventName = 'response';
-			eventStream.data = '{"data":"test"}\n';
-			eventStream.on('response', handler);
-
-			eventStream.parseEventStreamLine(0, -1, 0);
-
-			expect(handler).not.to.have.been.called;
-		});
-
 		it('emits error if the event handler crashes', () => {
 			const errorHandler = sinon.spy();
 			eventStream.event = true;

--- a/test/Particle.spec.js
+++ b/test/Particle.spec.js
@@ -3,7 +3,6 @@ import should from 'should'; // monkeypatch the world~!1
 import Particle from '../src/Particle';
 import Defaults from '../src/Defaults';
 import Client from '../src/Client';
-import { createServer } from 'http';
 import EventStream from '../src/EventStream';
 import FakeAgent from './FakeAgent';
 import {sinon, expect} from './test-setup';
@@ -755,11 +754,13 @@ describe('ParticleAPI', () => {
 		});
 		describe('.getEventStream', () => {
 			before(() => {
-				sinon.stub(EventStream.prototype, 'connect', function connect() {
-					return new Promise((resolve) => {
-						resolve({ uri: this.uri });
-					});
+				sinon.stub(EventStream.prototype, 'connect').callsFake(function connect() {
+					return Promise.resolve({ uri: this.uri });
 				});
+			});
+
+			after(() => {
+				sinon.restore();
 			});
 
 			it('requests public events', () => {

--- a/test/test-setup.js
+++ b/test/test-setup.js
@@ -5,7 +5,6 @@ import chai from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
-import sinonAsPromised from 'sinon-as-promised';
 
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
@@ -14,6 +13,5 @@ const expect = chai.expect;
 export {
 	chai,
 	sinon,
-	expect,
-	sinonAsPromised
+	expect
 };


### PR DESCRIPTION
Story details: https://app.clubhouse.io/particle/story/20875

Improve EventStream timeout and reconnection behavior.

New behavior:
- If the initial connection fails, the promise to `particle.getEventStream` will reject.
- When an event is received, only the `event` event will be emitted (instead of both `event` and `${particleEvent.name}` with potential conflicts if the Particle event name is the same as one of the internal events used in `EventStream` like `reconnect`)
- When a connection error or timeout error happens after initial connection, the `disconnect` event is emitted. 2 seconds later, the event stream will emit `reconnect` and attempt to reconnect. If it succeeds, it will emit `reconnect-success`. If it fails, it will emit `reconnect-error` and try again 2 seconds later indefinitely.
- To stop the auto-reconnect, call `stream.abort()` when receiving `disconnect`.
- If an event handler throws an exception, the event stream will catch it an emit `error`. It helps to avoid head scratching of a program appearing not to receive events when in fact it does receive events but the event handler is crashing.