### PR TITLE
Change Stream-Http to non-forked version

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.9.2",
-    "stream-http": "https://github.com/particle-iot/stream-http/archive/v2.2.1.tar.gz",
+    "stream-http": "^3.0.0",
     "form-data": ">2.2.0",
     "superagent": "^3.6.0",
     "superagent-prefix": "0.0.2"


### PR DESCRIPTION
The original Stream-Http has changed over to the pure js "readable-stream" implementation. This means that by switching to the non-forked stream-http, it is possible to use the particle-api-js with React Native provided the node-libs-react-native package is installed.

Note: I have only tested the Particle Cloud Functions and Variables at this time in React Native and not the "getEventStream", nor other API items yet. So there would be a need from someone to check those other calls to make sure they still work.