### PR TITLE
feature/ch69020/token-list-otp

### DIFF
--- a/src/Particle.js
+++ b/src/Particle.js
@@ -345,14 +345,16 @@ class Particle {
 	 * @param {Object} options            Options for this API call
 	 * @param {String} options.username   Username
 	 * @param {String} options.password   Password
+	 * @param {String} options.otp        Current one-time-password generated from the authentication application
 	 * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
 	 * @param {Object} [options.context]  Request context
 	 * @returns {Promise} A promise
 	 */
-	listAccessTokens({ username, password, headers, context }){
+	listAccessTokens({ username, password, otp, headers, context }){
 		return this.get({
 			uri: '/v1/access_tokens',
 			auth: { username, password },
+			query: otp ? { otp } : undefined,
 			headers,
 			context
 		});

--- a/test/Particle.spec.js
+++ b/test/Particle.spec.js
@@ -335,11 +335,37 @@ describe('ParticleAPI', () => {
 		});
 
 		describe('.listAccessTokens', () => {
+			let options;
+
+			beforeEach(() => {
+				options = {
+					username: props.username,
+					password: props.password,
+					otp: props.otp
+				};
+			});
+
 			it('sends credentials', () => {
-				return api.listAccessTokens(props).then(({ auth }) => {
-					auth.username.should.equal(props.username);
-					auth.password.should.equal(props.password);
-				});
+				delete options.otp;
+				return api.listAccessTokens(options)
+					.then(({ auth, query }) => {
+						expect(auth).to.be.an('object');
+						expect(auth).to.have.property('username', options.username);
+						expect(auth).to.have.property('password', options.password);
+						expect(query).to.equal(undefined);
+					});
+			});
+
+			it('includes otp when provided', () => {
+				return api.listAccessTokens(options)
+					.then(({ auth, query }) => {
+						expect(auth).to.be.an('object');
+						expect(auth).to.have.property('username', options.username);
+						expect(auth).to.have.property('password', options.password);
+						expect(query).to.be.an('object');
+						expect(query).to.have.property('otp', props.otp);
+						expect(props.otp).to.be.a('string').with.lengthOf(6);
+					});
 			});
 		});
 


### PR DESCRIPTION
https://app.clubhouse.io/particle/story/69357/listaccesstokens-should-accept-otp-option

### How to Test
1. Clone this repo and install dependencies
2. Launch `node`
3. Require the JS SDK - `var ParticleAPI = require('.');`
4. Create an instance - `var api = new API();`
5. Using an account with MFA enabled, list tokens _without_ an `otp` - `api.listAccessTokens({ username, password }).then(console.log, console.error);`
6. Verify that you receive an `MfaRequiredError` with status `403`
7. Repeat step 5 but add a valid `otp`
8. Verify that you receive your access tokens without error