### PR TITLE
Added tokenDuration parameter to loginAsClientOwner

### DIFF
--- a/src/Particle.js
+++ b/src/Particle.js
@@ -191,12 +191,13 @@ class Particle {
 
 	/**
 	 * Login to Particle Cloud using an OAuth client.
-	 * @param {Object} options            Options for this API call
-	 * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
-	 * @param {Object} [options.context]  Request context
+	 * @param {Object} options                Options for this API call
+	 * @param {Number} options.tokenDuration  How long the access token should last in seconds
+	 * @param {Object} [options.headers]      Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
+	 * @param {Object} [options.context]      Request context
 	 * @returns {Promise} A promise
 	 */
-	loginAsClientOwner({ headers, context }){
+	loginAsClientOwner({ tokenDuration = this.tokenDuration, headers, context }){
 		return this.request({
 			uri: '/oauth/token',
 			method: 'post',
@@ -204,7 +205,8 @@ class Particle {
 			form: {
 				grant_type: 'client_credentials',
 				client_id: this.clientId,
-				client_secret: this.clientSecret
+				client_secret: this.clientSecret,
+				expires_in: tokenDuration
 			},
 			context
 		});


### PR DESCRIPTION
Addresses #126

Added a parameter tokenDuration with the same behaviour as the login method. It will either use the value given in the parameter or the tokenDuration member value which can be set using the constructor or be the default 7776000 seconds.
