### PR TITLE
Fix library download in particle-api-js

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -101,8 +101,8 @@ export default class Client {
 		throw error;
 	}
 
-	downloadFile(url){
-		return this.api.downloadFile({ url });
+	downloadFile(uri){
+		return this.api.downloadFile({ uri });
 	}
 
 	/**

--- a/test/Client.spec.js
+++ b/test/Client.spec.js
@@ -56,8 +56,8 @@ describe('Client', () => {
 
 	describe('downloadFile', () => {
 		it('delegates to api', () => {
-			api.downloadFile = () => Promise.resolve('delegated');
-			return expect(client.downloadFile('url')).to.eventually.equal('delegated');
+			api.downloadFile = ({ uri }) => Promise.resolve(`${uri} delegated`);
+			return expect(client.downloadFile('uri')).to.eventually.equal('uri delegated');
 		});
 	});
 


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/93739

https://github.com/particle-iot/particle-api-js/releases/tag/v9.0.0 changed the syntax of `downloadFile` ([docs](https://github.com/particle-iot/particle-api-js/blob/master/docs/api.md#downloadfile)) but the library download method was still using the old syntax. I added a failing test and fixed the implementation.

I tested locally with `npm link particle-api-js` in the CLI repo and it fixes the `particle libraries install` command.

This blocks https://github.com/particle-iot/particle-cli/pull/617 so I'll do a particle-api-js release as soon as this is reviewed and passing CI.