### PR TITLE
Adds setBaseUrl method

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,23 +27,22 @@ $ bower install particle-api-js
 
 ## Development
 
+
 All essential commands are available at the root via `npm run <script name>` - e.g. `npm run lint`. To view the available commands, run: `npm run`
 
 <details id="develop-run-tests">
 <summary><b>How to run your tests</b></summary>
 <p>
 
-to run the tests:
+Some of the tests depend on a real HTTP api backend and a valid access token. Be sure to set relevant environment variables to avoid test failures. You can prefix commands test commands like this `PARTICLE_API_BASE_URL=foo PARTICLE_API_TOKEN=bar npm test`
 
-`npm test`
+`npm test` runs the tests.
 
-to run the coverage:
+`npm run coverage` shows code coverage 
 
-`npm run coverage`
+`npm run test:browser` runs browser tests with [karma](https://karma-runner.github.io/latest/index.html) (make sure you have the [Firefox launcher](https://npmjs.org/browse/keyword/karma-launcher) installed.
 
-to run browser tests with [karma](https://karma-runner.github.io/latest/index.html) (make sure you have the [Firefox launcher](https://npmjs.org/browse/keyword/karma-launcher) installed):
-
-`npm run test:browser`
+`npm run test:ci` runs tests in the exact same way CI system does
 
 </p>
 </details>

--- a/README.md
+++ b/README.md
@@ -47,6 +47,29 @@ Some of the tests depend on a real HTTP api backend and a valid access token. Be
 </p>
 </details>
 
+<details id="develop-run-locally">
+<summary><b>How to write scripts that execute against local code changes?</b></summary>
+<p>
+
+Changes to source code happens in `src` directory. However, executable code that eventually ends up in a release gets compiled into `lib`.
+
+You can compile code via `npm run compile`.
+
+Node.js scripts that run against compiled code, typically start out like this:
+
+```js
+const Particle = require('./lib/Particle');
+const username = 'TBD';
+const password = 'TBD';
+const particle = new Particle();
+// Put specific api calls against `particle` here...
+```
+
+After you make a change to files in `src`, be sure to run the compile command again before re-executing your script
+
+</p>
+</details>
+
 
 <details id="develop-npm-scripts">
 <summary><b>How to name npm scripts</b></summary>

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ All essential commands are available at the root via `npm run <script name>` - e
 <summary><b>How to run your tests</b></summary>
 <p>
 
-Some of the tests depend on a real HTTP api backend and a valid access token. Be sure to set relevant environment variables to avoid test failures. You can prefix commands test commands like this `PARTICLE_API_BASE_URL=foo PARTICLE_API_TOKEN=bar npm test`
+The `Agent` integration tests ([source](./test/Agent.integration.js)) depend on a real HTTP api backend and a valid Particle access token. Be sure to set relevant environment variables to avoid test failures. You can prefix commands test commands like this `PARTICLE_API_BASE_URL=<url> PARTICLE_API_TOKEN=<token> npm test`
 
 `npm test` runs the tests.
 

--- a/README.md
+++ b/README.md
@@ -51,21 +51,27 @@ The `Agent` integration tests ([source](./test/Agent.integration.js)) depend on 
 <summary><b>How to write scripts that execute against local code changes?</b></summary>
 <p>
 
-Changes to source code happens in `src` directory. However, executable code that eventually ends up in a release gets compiled into `lib`.
+Source code lives in the `./src` directory and is built for release via the `npm run compile` command. To create a simple script file to test your changes, follow these steps:
 
-You can compile code via `npm run compile`.
-
-Node.js scripts that run against compiled code, typically start out like this:
+1. create a `js` file on your local machine: `touch my-api-test.js` (somewhere outside of the root of this repo)
+2. within your test `js` file, init the api client like so:
 
 ```js
-const Particle = require('./lib/Particle');
-const username = 'TBD';
-const password = 'TBD';
-const particle = new Particle();
-// Put specific api calls against `particle` here...
+const ParticleAPI = require('./path/to/particle-api-js'); // Make sure to substitute to correct path
+const api = new ParticleAPI();
 ```
 
-After you make a change to files in `src`, be sure to run the compile command again before re-executing your script
+3. add in any api calls, etc required to validate you changes
+
+```js
+const devices = await api.listDevices({ auth: '<particle-auth-token>' });
+console.log('MY DEVICES:', devices);
+```
+
+4. run it: `node ./path/to/my-api-test.js`
+
+_NOTE: Requiring the root directory works via the `main` field specified in Particle API JS' `package.json` file ([docs](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#main))_ 
+
 
 </p>
 </details>

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The `Agent` integration tests ([source](./test/Agent.integration.js)) depend on 
 
 `npm run coverage` shows code coverage 
 
-`npm run test:browser` runs browser tests with [karma](https://karma-runner.github.io/latest/index.html) (make sure you have the [Firefox launcher](https://npmjs.org/browse/keyword/karma-launcher) installed.
+`npm run test:browser` runs tests in a browser via [karma](https://karma-runner.github.io/latest/index.html).
 
 `npm run test:ci` runs tests in the exact same way CI system does
 

--- a/src/Agent.js
+++ b/src/Agent.js
@@ -22,6 +22,10 @@ import prefix from 'superagent-prefix';
 
 export default class Agent {
 	constructor(baseUrl){
+		this.setBaseUrl(baseUrl);
+	}
+
+	setBaseUrl(baseUrl) {
 		this.prefix = prefix(baseUrl);
 	}
 

--- a/src/Particle.js
+++ b/src/Particle.js
@@ -2144,6 +2144,11 @@ class Particle {
 	client(options = {}){
 		return new Client(Object.assign({ api: this }, options));
 	}
+
+	// Internal method used to target Particle's APIs other than the default
+	setBaseUrl(baseUrl){
+		this.agent.setBaseUrl(baseUrl);
+	}
 }
 
 // Aliases for backwards compatibility

--- a/test/Agent.spec.js
+++ b/test/Agent.spec.js
@@ -1,8 +1,30 @@
 import { sinon, expect } from './test-setup';
 import Agent from '../src/Agent.js';
 
-
 describe('Agent', () => {
+	beforeEach(() => {
+		sinon.restore();
+	});
+
+	describe('constructor', () => {
+		it('calls setBaseUrl', () => {
+			const baseUrl = 'https://foo.com';
+			sinon.stub(Agent.prototype, 'setBaseUrl');
+			const agent = new Agent(baseUrl);
+			expect(agent.setBaseUrl).to.have.property('callCount', 1);
+			expect(agent.setBaseUrl.firstCall.args).to.have.lengthOf(1);
+			expect(agent.setBaseUrl.firstCall.args[0]).to.eql(baseUrl);
+		});
+
+		it('creates a prefix function instance property from the supplied baseUrl (via setBaseUrl)', () => {
+			const agent = new Agent();
+			expect(agent.prefix).to.be.a('Function');
+			// Note: validating specific .prefix function behavior seems hard without proxyquire
+			// and this test seems sufficient
+			// and redundant with the 'build request uses prefix if provided' test below
+		});
+	});
+
 	describe('sanitize files', () => {
 		it('can call sanitize will falsy value', () => {
 			const agent = new Agent();

--- a/test/Particle.spec.js
+++ b/test/Particle.spec.js
@@ -2701,4 +2701,19 @@ describe('ParticleAPI', () => {
 			});
 		});
 	});
+
+	describe('setBaseUrl(baseUrl)', () => {
+		afterEach(() => {
+			sinon.restore();
+		});
+
+		it('calls agent.setBaseUrl', () => {
+			const baseUrl = 'foo';
+			sinon.stub(api.agent, 'setBaseUrl');
+			api.setBaseUrl(baseUrl);
+			expect(api.agent.setBaseUrl).to.have.property('callCount', 1);
+			expect(api.agent.setBaseUrl.firstCall.args).to.have.lengthOf(1);
+			expect(api.agent.setBaseUrl.firstCall.args[0]).to.eql(baseUrl);
+		});
+	});
 });


### PR DESCRIPTION
## Overview

Adds `setBaseUrl()` method to `Particle` class so url can be changed after instantiation. This ability is useful for internal purposes in platform development & automated testing situations. See [sc-104326](https://app.shortcut.com/particle/story/104326/particle-api-js-supports-setting-baseurl-after-initialization)

## How to test?

See comment in story: https://app.shortcut.com/particle/story/104326/particle-api-js-supports-setting-baseurl-after-initialization#activity-104901
