### PR TITLE
Fix issue with peerDependencies coming from sinon and chai

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,8 @@
         "babelify": "^7.3.0",
         "brfs": "^1.4.3",
         "browserify": "^13.0.0",
-        "chai": "^3.5.0",
-        "chai-as-promised": "^5.3.0",
+        "chai": "^4.3.6",
+        "chai-as-promised": "^7.1.1",
         "documentation": "^4.0.0-rc.1",
         "eslint": "^5.16.0",
         "eslint-config-particle": "^2.2.1",
@@ -42,8 +42,7 @@
         "nyc": "^15.1.0",
         "should": "^9.0.0",
         "sinon": "^7.2.5",
-        "sinon-as-promised": "^4.0.3",
-        "sinon-chai": "^3.3.0",
+        "sinon-chai": "^3.7.0",
         "watchify": "^3.7.0"
       },
       "engines": {
@@ -678,15 +677,6 @@
         "type-detect": "4.0.8"
       }
     },
-    "node_modules/@sinonjs/commons/node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@sinonjs/formatio": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.0.tgz",
@@ -740,10 +730,11 @@
       }
     },
     "node_modules/acorn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1040,9 +1031,9 @@
       }
     },
     "node_modules/assertion-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -2821,26 +2812,33 @@
       }
     },
     "node_modules/chai": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
       "dev": true,
       "dependencies": {
-        "assertion-error": "^1.0.1",
-        "deep-eql": "^0.1.3",
-        "type-detect": "^1.0.0"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
       },
       "engines": {
-        "node": ">= 0.4.0"
+        "node": ">=4"
       }
     },
     "node_modules/chai-as-promised": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz",
-      "integrity": "sha1-CdekApCKpw39vq1T5YU/x50+8hw=",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dev": true,
+      "dependencies": {
+        "check-error": "^1.0.2"
+      },
       "peerDependencies": {
-        "chai": ">= 2.1.2 < 4"
+        "chai": ">= 2.1.2 < 5"
       }
     },
     "node_modules/chalk": {
@@ -2888,6 +2886,15 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/chokidar": {
       "version": "1.7.0",
@@ -3326,19 +3333,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "node_modules/create-thenable": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/create-thenable/-/create-thenable-1.0.2.tgz",
-      "integrity": "sha1-4gMXIMzJV12M+jH1wUbnYqgMBTQ=",
-      "dev": true,
-      "dependencies": {
-        "object.omit": "~2.0.0",
-        "unique-concat": "~0.2.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -3444,24 +3438,15 @@
       }
     },
     "node_modules/deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "dependencies": {
-        "type-detect": "0.1.1"
+        "type-detect": "^4.0.0"
       },
       "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/deep-eql/node_modules/type-detect": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-      "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-      "dev": true,
-      "engines": {
-        "node": "*"
+        "node": ">=0.12"
       }
     },
     "node_modules/deep-is": {
@@ -4798,6 +4783,18 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/falafel/node_modules/acorn": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/falafel/node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -5872,6 +5869,15 @@
       "resolved": "https://registry.npmjs.org/get-comments/-/get-comments-1.0.1.tgz",
       "integrity": "sha1-GWdZEBu7xPrPEwYMqu3Uhw3uVb4=",
       "dev": true
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
@@ -8067,6 +8073,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/loupe": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.0"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
@@ -8802,12 +8817,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/native-promise-only": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
-      "dev": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -10012,6 +10021,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/pbkdf2": {
       "version": "3.0.14",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
@@ -11071,27 +11089,14 @@
         "supports-color": "^5.5.0"
       }
     },
-    "node_modules/sinon-as-promised": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/sinon-as-promised/-/sinon-as-promised-4.0.3.tgz",
-      "integrity": "sha1-wFRbFoX9gTWIpO1pcBJIftEdFRs=",
-      "dev": true,
-      "dependencies": {
-        "create-thenable": "~1.0.0",
-        "native-promise-only": "~0.8.1"
-      },
-      "peerDependencies": {
-        "sinon": "1"
-      }
-    },
     "node_modules/sinon-chai": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.3.0.tgz",
-      "integrity": "sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
       "dev": true,
       "peerDependencies": {
         "chai": "^4.0.0",
-        "sinon": ">=4.0.0 <8.0.0"
+        "sinon": ">=4.0.0"
       }
     },
     "node_modules/sinon/node_modules/diff": {
@@ -12513,12 +12518,12 @@
       }
     },
     "node_modules/type-detect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true,
       "engines": {
-        "node": "*"
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -12704,12 +12709,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/unique-concat": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/unique-concat/-/unique-concat-0.2.2.tgz",
-      "integrity": "sha1-khD5vcqsxeHjkpSQ18AZ35bxhxI=",
-      "dev": true
     },
     "node_modules/unique-stream": {
       "version": "2.2.1",
@@ -14160,14 +14159,6 @@
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "4.0.8",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-          "dev": true
-        }
       }
     },
     "@sinonjs/formatio": {
@@ -14222,10 +14213,11 @@
       }
     },
     "acorn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
-      "dev": true
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.1.0",
@@ -14459,9 +14451,9 @@
       }
     },
     "assertion-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "astral-regex": {
@@ -16126,22 +16118,28 @@
       }
     },
     "chai": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "deep-eql": "^0.1.3",
-        "type-detect": "^1.0.0"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
       }
     },
     "chai-as-promised": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz",
-      "integrity": "sha1-CdekApCKpw39vq1T5YU/x50+8hw=",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dev": true,
-      "requires": {}
+      "requires": {
+        "check-error": "^1.0.2"
+      }
     },
     "chalk": {
       "version": "1.1.3",
@@ -16184,6 +16182,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true
     },
     "chokidar": {
@@ -16569,16 +16573,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "create-thenable": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/create-thenable/-/create-thenable-1.0.2.tgz",
-      "integrity": "sha1-4gMXIMzJV12M+jH1wUbnYqgMBTQ=",
-      "dev": true,
-      "requires": {
-        "object.omit": "~2.0.0",
-        "unique-concat": "~0.2.2"
-      }
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -16665,20 +16659,12 @@
       "dev": true
     },
     "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "0.1.1"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-          "dev": true
-        }
+        "type-detect": "^4.0.0"
       }
     },
     "deep-is": {
@@ -17806,6 +17792,12 @@
         "object-keys": "^1.0.6"
       },
       "dependencies": {
+        "acorn": {
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+          "dev": true
+        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -18644,6 +18636,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-comments/-/get-comments-1.0.1.tgz",
       "integrity": "sha1-GWdZEBu7xPrPEwYMqu3Uhw3uVb4=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true
     },
     "get-package-type": {
@@ -20451,6 +20449,15 @@
         "signal-exit": "^3.0.0"
       }
     },
+    "loupe": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "dev": true,
+      "requires": {
+        "get-func-name": "^2.0.0"
+      }
+    },
     "lru-cache": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
@@ -21060,12 +21067,6 @@
           "dev": true
         }
       }
-    },
-    "native-promise-only": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
-      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -22037,6 +22038,12 @@
         }
       }
     },
+    "pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true
+    },
     "pbkdf2": {
       "version": "3.0.14",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
@@ -22943,20 +22950,10 @@
         }
       }
     },
-    "sinon-as-promised": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/sinon-as-promised/-/sinon-as-promised-4.0.3.tgz",
-      "integrity": "sha1-wFRbFoX9gTWIpO1pcBJIftEdFRs=",
-      "dev": true,
-      "requires": {
-        "create-thenable": "~1.0.0",
-        "native-promise-only": "~0.8.1"
-      }
-    },
     "sinon-chai": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.3.0.tgz",
-      "integrity": "sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
       "dev": true,
       "requires": {}
     },
@@ -24146,9 +24143,9 @@
       }
     },
     "type-detect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "type-fest": {
@@ -24305,12 +24302,6 @@
           }
         }
       }
-    },
-    "unique-concat": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/unique-concat/-/unique-concat-0.2.2.tgz",
-      "integrity": "sha1-khD5vcqsxeHjkpSQ18AZ35bxhxI=",
-      "dev": true
     },
     "unique-stream": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "babelify": "^7.3.0",
     "brfs": "^1.4.3",
     "browserify": "^13.0.0",
-    "chai": "^3.5.0",
-    "chai-as-promised": "^5.3.0",
+    "chai": "^4.3.6",
+    "chai-as-promised": "^7.1.1",
     "documentation": "^4.0.0-rc.1",
     "eslint": "^5.16.0",
     "eslint-config-particle": "^2.2.1",
@@ -72,8 +72,7 @@
     "nyc": "^15.1.0",
     "should": "^9.0.0",
     "sinon": "^7.2.5",
-    "sinon-as-promised": "^4.0.3",
-    "sinon-chai": "^3.3.0",
+    "sinon-chai": "^3.7.0",
     "watchify": "^3.7.0"
   },
   "dependencies": {

--- a/test/Agent.spec.js
+++ b/test/Agent.spec.js
@@ -28,7 +28,7 @@ describe('Agent', () => {
 	describe('sanitize files', () => {
 		it('can call sanitize will falsy value', () => {
 			const agent = new Agent();
-			expect(agent._sanitizeFiles(undefined)).to.be.falsy;
+			expect(agent._sanitizeFiles(undefined)).to.be.undefined;
 		});
 
 		it('sanitizes file names', () => {
@@ -247,13 +247,14 @@ describe('Agent', () => {
 		});
 
 		it('does not call used if no prefix provided', () => {
+			agent.prefix = undefined;
 			const use = sinon.stub();
 			const req = sinon.stub();
 			req.returns({ use: use });
 			const result = agent._buildRequest({ uri: 'uri', method: 'get', makerequest: req });
 			expect(result).to.be.ok;
 			expect(req).to.be.calledWith('get', 'uri');
-			expect(use).to.be.notCalled;
+			expect(use).to.not.have.been.called;
 		});
 
 		it('should invoke _applyContext with the request and context when provided', () => {
@@ -302,7 +303,7 @@ describe('Agent', () => {
 			const req = sinon.stub();
 			req.returns({ query: query, _authorizationHeader: sinon.stub() });
 			agent._buildRequest({ uri: 'uri', method: 'get', makerequest: req });
-			expect(query).to.be.notCalled;
+			expect(query).to.be.not.been.called;
 		});
 
 		it('should invoke send when data given', () => {

--- a/test/EventStream.spec.js
+++ b/test/EventStream.spec.js
@@ -26,7 +26,7 @@ describe('EventStream', () => {
 		it('creates an EventStream objects', () => {
 			const eventStream = new EventStream('uri', 'token');
 
-			expect(eventStream).to.be.obj;
+			expect(eventStream).to.own.include({ uri: 'uri', token: 'token' });
 		});
 	});
 


### PR DESCRIPTION
## Description
The dependencies `sinon-as-promised`, `sinon-chai` and `chai` were causing issues due to peerDependencies now being installed by default and said packages pointing to incompatible dependency versions between them.

## How to Test

1. Pull the branch: `bug/sc-104915/error-when-installing-dependencies-in-particle`
2. Update your local node version to `v16.x` and npm to version to `v8.x`. Use `nvm use 16` or equivalent.
3. Verify your updates: `node -v && npm -v`. **Make sure you are running `npm@8.11.x` or higher**.
4. Install dependencies: `npm i`
5. Run the tests `npm run test`

**Outcome**
All tests should pass. npm i should run without issues.

## Related / Discussions

<!--
	Link to the story for your changes
	e.g. https://app.clubhouse.io/particle/story/76223/command-toolchain

	Link to related PR
	e.g. https://github.com/particle-iot/cli/pull/37

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->
- https://app.shortcut.com/particle/story/104915/error-when-installing-dependencies-in-particle-api-js-with-npm-8-11-0

## Completeness

- [x] PR opened :tada:
- [x] Testing instructions have been provided
- [x] Tracking story is up to date (tasks are marked complete, state is "ready for review")
- [x] Docs have been updated
- [x] Branch is rebased against _target_ (typically `main`)