### PR TITLE
Support setting access token per-instance in addition to accepting it as an arg to each method

### DIFF
--- a/src/Particle.js
+++ b/src/Particle.js
@@ -2100,6 +2100,15 @@ class Particle {
 	}
 
 	/**
+	 * Set default auth token that will be used in each method if `auth` is not provided
+	 * @param  {String} auth A Particle access token
+	 * @returns {undefined}
+	 */
+	setDefaultAuth(auth){
+		this._defaultAuth = auth;
+	}
+
+	/**
 	 * API URI to access a device
 	 * @param  {Object} options Options for this API call
 	 * @param  {String} options.deviceId  Device ID to access

--- a/test/Particle.spec.js
+++ b/test/Particle.spec.js
@@ -2716,4 +2716,16 @@ describe('ParticleAPI', () => {
 			expect(api.agent.setBaseUrl.firstCall.args[0]).to.eql(baseUrl);
 		});
 	});
+
+	describe('setDefaultAuth(auth)', () => {
+		afterEach(() => {
+			sinon.restore();
+		});
+
+		it('sets ._defaultAuth', () => {
+			const auth = 'foo';
+			api.setDefaultAuth(auth);
+			expect(api._defaultAuth).to.eql(auth);
+		});
+	});
 });


### PR DESCRIPTION
WIP

Story details: https://app.shortcut.com/particle/story/76665



## How to test?


Create a `foo.js` script like this:

```
const ParticleAPI = require('./particle-api-js');

async function main() {
    const api = new ParticleAPI();
    api.setDefaultAuthToken('redacted');
    const devices = await api.listDevices();
    console.log(devices)
}
main();
```