### PR TITLE
Don't add an empty query string to the URL

### DIFF
--- a/src/Agent.js
+++ b/src/Agent.js
@@ -255,8 +255,10 @@ class Agent {
         }
         if (query) {
             const queryParams = qs.stringify(query);
-            const hasParams = actualUri.includes('?');
-            actualUri = `${actualUri}${hasParams ? '&' : '?'}${queryParams}`;
+            if (queryParams) {
+                const hasParams = actualUri.includes('?');
+                actualUri = `${actualUri}${hasParams ? '&' : '?'}${queryParams}`;
+            }
         }
 
         const userAgentHeader = { 'User-Agent': `${packageJson.name}/${packageJson.version} (${packageJson.repository.url})` };


### PR DESCRIPTION
Fix making URLs like `https://api.particle.io/v1/logic/functions?` when all query params are undefined.