### PR TITLE
Add DeviceOS versions endpoints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1
+  browser-tools: circleci/browser-tools@1.4.8
 
 jobs:
   run-tests:
@@ -25,9 +25,7 @@ jobs:
           condition:
             equal: ["16.20.0", << parameters.node-version >>]
           steps:
-            - browser-tools/install-browser-tools:
-                # Workaround for circleCI automatically targeting unstalbe build https://github.com/CircleCI-Public/browser-tools-orb/issues/90
-                chrome-version: 116.0.5845.96 # TODO: remove when chromedriver downloads are fixed
+            - browser-tools/install-browser-tools
             - run:
                 name: Run tests with browser
                 command: npm run test:browser

--- a/src/Particle.js
+++ b/src/Particle.js
@@ -2663,6 +2663,29 @@ class Particle {
     }
 
     /**
+     * Get a specific Device OS version
+     *
+     * @param {Object} options               Options for this API call
+     * @param {String} options.version       Version of the Device OS
+     * @param {Number} [options.platformId]  Optional platform ID to filter Device OS version
+     * @param {Auth}   [options.auth]        The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {Object} [options.headers]     Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
+     * @param {Object} [options.context]     Request context
+     *
+     * @returns {Promise<RequestResponse>}        A promise that resolves to the specified Device OS version data.
+     */
+    getDeviceOsVersion({ version, platformId, auth, headers, context }) {
+        const query = platformId ? { platform_id: platformId } : {};
+        return this.get({
+            uri: `/v1/device-os/versions/${version}`,
+            query,
+            auth,
+            headers,
+            context
+        });
+    }
+
+    /**
      * Set default auth token that will be used in each method if `auth` is not provided
      * @param {Auth} auth The access token or basic auth object
      * @throws {Error} When not auth string is provided

--- a/src/Particle.js
+++ b/src/Particle.js
@@ -2632,6 +2632,37 @@ class Particle {
     }
 
     /**
+     * List Device OS versions
+     *
+     * @param {Object} options                    Options for this API call
+     * @param {Number} [options.platformId]       Platform ID to filter Device OS versions
+     * @param {Number} [options.internalVersion]  Internal version number to filter Device OS versions
+     * @param {Number} [options.page]             Page number for pagination
+     * @param {Number} [options.perPage]          Number of items per page
+     * @param {Auth}   [options.auth]             The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {Object} [options.headers]          Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
+     * @param {Object} [options.context]          Request context
+     *
+     * @returns {Promise<RequestResponse>}        A promise that resolves to the list of Device OS versions.
+     */
+    listDeviceOsVersions({ platformId, internalVersion, page, perPage, auth, headers, context }) {
+        const query = {
+            platform_id: platformId,
+            internal_version: internalVersion,
+            page,
+            per_page: perPage
+        };
+
+        return this.get({
+            uri: '/v1/device-os/versions',
+            query,
+            auth,
+            headers,
+            context
+        });
+    }
+
+    /**
      * Set default auth token that will be used in each method if `auth` is not provided
      * @param {Auth} auth The access token or basic auth object
      * @throws {Error} When not auth string is provided

--- a/test/Particle.spec.js
+++ b/test/Particle.spec.js
@@ -2925,6 +2925,41 @@ describe('ParticleAPI', () => {
             });
         });
 
+        describe('.getDeviceOsVersion', () => {
+            it('generates request without optional parameters', () => {
+                const options = {
+                    auth: props.auth,
+                    version: '1.2.3'
+                };
+                return api.getDeviceOsVersion(options).then((results) => {
+                    results.should.match({
+                        method: 'get',
+                        uri: '/v1/device-os/versions/1.2.3',
+                        auth: props.auth,
+                        query: {}
+                    });
+                });
+            });
+
+            it('generates request with platformId parameter', () => {
+                const options = {
+                    auth: props.auth,
+                    version: '1.2.3',
+                    platformId: 6
+                };
+                return api.getDeviceOsVersion(options).then((results) => {
+                    results.should.match({
+                        method: 'get',
+                        uri: '/v1/device-os/versions/1.2.3',
+                        auth: props.auth,
+                        query: {
+                            platform_id: 6
+                        }
+                    });
+                });
+            });
+        });
+
         describe('.unprotectDevice', () => {
             it('generates request', () => {
                 return api.unprotectDevice(Object.assign({}, propsWithProduct, {

--- a/test/Particle.spec.js
+++ b/test/Particle.spec.js
@@ -2889,6 +2889,42 @@ describe('ParticleAPI', () => {
             });
         });
 
+        describe('.listDeviceOsVersions', () => {
+            it('generates request without optional parameters', () => {
+                return api.listDeviceOsVersions({ auth: props.auth }).then((results) => {
+                    results.should.match({
+                        method: 'get',
+                        uri: '/v1/device-os/versions',
+                        auth: props.auth,
+                        query: {}
+                    });
+                });
+            });
+
+            it('generates request with all optional parameters', () => {
+                const options = {
+                    auth: props.auth,
+                    platformId: 6,
+                    internalVersion: '1.2.3',
+                    page: 2,
+                    perPage: 25
+                };
+                return api.listDeviceOsVersions(options).then((results) => {
+                    results.should.match({
+                        method: 'get',
+                        uri: '/v1/device-os/versions',
+                        auth: props.auth,
+                        query: {
+                            platform_id: 6,
+                            internal_version: '1.2.3',
+                            page: 2,
+                            per_page: 25
+                        }
+                    });
+                });
+            });
+        });
+
         describe('.unprotectDevice', () => {
             it('generates request', () => {
                 return api.unprotectDevice(Object.assign({}, propsWithProduct, {


### PR DESCRIPTION
The PR adds functions for listing and getting DeviceOS versions.

See: https://app.shortcut.com/particle/story/129513/use-the-deviceos-versions-endpoints-when-compiling?vc_group_by=day&ct_workflow=all&cf_workflow=500127125