### PR TITLE
feat: [sc-130912] Remove token delete/list APIs from particle-api-js

### DIFF
--- a/src/Agent.js
+++ b/src/Agent.js
@@ -24,10 +24,6 @@ const fs = require('../fs');
 const packageJson = require('../package.json');
 
 /**
- * @typedef {string} Auth Access token to use for the request
- */
-
-/**
  * The object returned for a basic request
  * @typedef {object} JSONResponse
  * @property {number} statusCode  The HTTP response status
@@ -63,7 +59,7 @@ class Agent {
      * Make a GET request
      * @param {object} params            Configurations to customize the request
      * @param {string} params.uri        The URI to request
-     * @param {Auth}   [params.auth]     Authorization token to use
+     * @param {string} [params.auth]     Authorization token to use
      * @param {object} [params.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {object} [params.query]    Key/Value pairs of query params
      * @param {object} [params.context]  The invocation context, describing the tool and project
@@ -77,7 +73,7 @@ class Agent {
      * Make a HEAD request
      * @param {object} params            Configurations to customize the request
      * @param {string} params.uri        The URI to request
-     * @param {Auth}   [params.auth]     Authorization token to use
+     * @param {string} [params.auth]     Authorization token to use
      * @param {object} [params.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {object} [params.query]    Key/Value pairs of query params
      * @param {object} [params.context]  The invocation context, describing the tool and project
@@ -91,7 +87,7 @@ class Agent {
      * Make a POST request
      * @param {object} params            Configurations to customize the request
      * @param {string} params.uri        The URI to request
-     * @param {Auth}   [params.auth]     Authorization token to use
+     * @param {string} [params.auth]     Authorization token to use
      * @param {object} [params.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {object} [params.data]     Request body
      * @param {object} [params.context]  The invocation context, describing the tool and project
@@ -105,7 +101,7 @@ class Agent {
      * Make a PUT request
      * @param {object} params            Configurations to customize the request
      * @param {string} params.uri        The URI to request
-     * @param {Auth}   [params.auth]     Authorization token to use
+     * @param {string} [params.auth]     Authorization token to use
      * @param {object} [params.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {object} [params.data]     Request body
      * @param {object}          [params.query]    Key/Value pairs of query params or a correctly formatted string
@@ -120,7 +116,7 @@ class Agent {
      * Make a DELETE request
      * @param {object} params            Configurations to customize the request
      * @param {string} params.uri        The URI to request
-     * @param {Auth}   [params.auth]     Authorization token to use
+     * @param {string} [params.auth]     Authorization token to use
      * @param {object} [params.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {object} [params.data]     Request body
      * @param {object} [params.context]  The invocation context, describing the tool and project
@@ -137,7 +133,7 @@ class Agent {
      * @param {string}  config.method           The method used to request the URI, should be in uppercase.
      * @param {object}  [config.headers]        Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {object}  [config.data]           Arbitrary data to send as the body.
-     * @param {Auth}    [config.auth]           Authorization
+     * @param {string}  [config.auth]           Authorization
      * @param {object}  [config.query]          Query parameters
      * @param {object}  [config.form]           Form fields
      * @param {object}  [config.files]          Array of file names and file content
@@ -230,7 +226,7 @@ class Agent {
      * @param {string} config.method     The method used to request the URI, should be in uppercase.
      * @param {object} [config.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {object} [config.data]     Arbitrary data to send as the body.
-     * @param {Auth}   [config.auth]     Authorization
+     * @param {string} [config.auth]     Authorization
      * @param {object} [config.query]    Query parameters
      * @param {object} [config.form]     Form fields
      * @param {object} [config.files]    Array of file names and file content
@@ -380,7 +376,7 @@ class Agent {
 
     /**
      * Adds an authorization header.
-     * @param {Auth} [auth]  The authorization bearer token.
+     * @param {string} [auth]  The authorization bearer token.
      * @returns {object} The original request.
      */
     _getAuthorizationHeader(auth){

--- a/src/Agent.js
+++ b/src/Agent.js
@@ -24,17 +24,7 @@ const fs = require('../fs');
 const packageJson = require('../package.json');
 
 /**
- * @typedef {string} AccessToken
- */
-
-/**
- * @typedef {object} BasicAuth
- * @property {string} username
- * @property {string} password
- */
-
-/**
- * @typedef {AccessToken | BasicAuth} Auth Prefer using an access token over basic auth for better security
+ * @typedef {string} Auth Access token to use for the request
  */
 
 /**
@@ -394,20 +384,11 @@ class Agent {
      * @returns {object} The original request.
      */
     _getAuthorizationHeader(auth){
-        if (!auth) {
-            return {};
-        }
         if (typeof auth === 'string') {
             return { Authorization: `Bearer ${auth}` };
         }
-        let encoded;
-        if (this.isForBrowser()) {
-            encoded = btoa(`${auth.username}:${auth.password}`);
-        } else {
-            encoded = Buffer.from(`${auth.username}:${auth.password}`)
-                .toString('base64');
-        }
-        return { Authorization: `Basic ${encoded}` };
+
+        return {};
     }
 
     /**

--- a/src/Particle.js
+++ b/src/Particle.js
@@ -14,7 +14,6 @@ const Client = require('./Client');
  *
  * @typedef {import('./Agent').RequestResponse} RequestResponse
  * @typedef {import('./Agent').RequestError} RequestError
- * @typedef {import('./Agent').Auth} Auth
  */
 // These typedef avoid importing the type on every @return statement
 class Particle {
@@ -28,7 +27,7 @@ class Particle {
      * @param {string} [options.clientSecret]
      * @param {string} [options.clientId]
      * @param {number} [options.tokenDuration]
-     * @param {Auth}   [options.auth]           The access token or basic auth object. If not specified here, will have to be added to every request
+     * @param {string} [options.auth]           The access token. If not specified here, will have to be added to every request
      */
     constructor(options = {}){
         if (options.auth) {
@@ -125,7 +124,7 @@ class Particle {
     /**
      * Enable MFA on the currently logged in user
      * @param {Object} options            Options for this API call
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -137,7 +136,7 @@ class Particle {
     /**
      * Confirm MFA for the user. This must be called with current TOTP code, determined from the results of enableMfa(). You will be prompted to enter an OTP code every time you login after enrollment is confirmed.
      * @param {Object} options                    Options for this API call
-     * @param {Auth} [options.auth]               The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]               The access token. Can be ignored if provided in constructor
      * @param {Object} options.mfaToken           Token given from previous step to
      * @param {Object} options.otp                Current one-time-password generated from the authentication app
      * @param {Boolean} options.invalidateTokens  Should all tokens be invalidated
@@ -164,7 +163,7 @@ class Particle {
     /**
      * Disable MFA for the user.
      * @param {Object} options                  Options for this API call
-     * @param {Auth} [options.auth]             The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]             The access token. Can be ignored if provided in constructor
      * @param {Object} options.currentPassword  User's current password
      * @param {Object} [options.headers]        Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]        Request context
@@ -293,7 +292,7 @@ class Particle {
     /**
      * Revoke the current session access token
      * @param {Object} options            Options for this API call
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -310,7 +309,7 @@ class Particle {
     /**
      * Revoke all active access tokens
      * @param {Object} options            Options for this API call
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -327,7 +326,7 @@ class Particle {
     /**
      * Delete the current user
      * @param {Object} options            Options for this API call
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {String} options.password   Password
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
@@ -346,7 +345,7 @@ class Particle {
     /**
      * Retrieves the information that is used to identify the current login for tracking.
      * @param {Object}  [options]          Options for this API call
-     * @param {Auth}    [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string}  [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Boolean} [options.full]     When true, retrieve all information for registering a user with the tracking API. When false,
      *                                     retrieve only the unique tracking ID for the current login.
      * @param {Object}  [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
@@ -374,7 +373,7 @@ class Particle {
      * @param {Number}         [options.page]        (Product only) Current page of results
      * @param {Number}         [options.perPage]     (Product only) Records per page
      * @param {String}         [options.product]     List devices in this product ID or slug
-     * @param {Auth}           [options.auth]        The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string}         [options.auth]        The access token. Can be ignored if provided in constructor
      * @param {Object}         [options.headers]     Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object}         [options.context]     Request context
      * @returns {Promise} A promise
@@ -405,7 +404,7 @@ class Particle {
      * @param {Object} options            Options for this API call
      * @param {String} options.deviceId   Device ID or Name
      * @param {String} [options.product]  Device in this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -419,7 +418,7 @@ class Particle {
      * Claim a device to the account. The device must be online and unclaimed.
      * @param {Object}  options                  Options for this API call
      * @param {String}  options.deviceId         Device ID
-     * @param {Auth}    [options.auth]           The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string}  [options.auth]           The access token. Can be ignored if provided in constructor
      * @param {boolean} options.requestTransfer  True to request the device be transfered from another user
      * @param {Object}  [options.headers]        Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object}  [options.context]        Request context
@@ -445,7 +444,7 @@ class Particle {
      * @param {Object} options.file       A file that contains a single-column list of device IDs, device serial numbers, device IMEIs, or devie ICCIDs.
      *                                    Node: Either a path or Buffer. Browser: a File or Blob.
      * @param {String} options.product    Add to this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -476,7 +475,7 @@ class Particle {
      * @param {String}  options.deviceId   Device ID or Name
      * @param {Boolean} [options.deny]     (Product only) Deny this quarantined device, instead of removing an already approved device
      * @param {String}  options.product    Remove from this product ID or slug
-     * @param {Auth}    [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string}  [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object}  [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object}  [options.context]  Request context
      * @returns {Promise} A promise
@@ -492,7 +491,7 @@ class Particle {
      * @param {Object} options            Options for this API call
      * @param {String} options.deviceId   Device ID or Name
      * @param {String} options.product    Remove from this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -508,7 +507,7 @@ class Particle {
      * @param {String} options.deviceId   Device ID or Name
      * @param {String} options.name       Desired Name
      * @param {String} [options.product]  Rename device in this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -523,7 +522,7 @@ class Particle {
      * @param {String} options.deviceId   Device ID or Name
      * @param {Boolean} options.signal    Signal on or off
      * @param {String} [options.product]  Device in this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -538,7 +537,7 @@ class Particle {
      * @param {String} options.deviceId   Device ID or Name
      * @param {String} options.notes      Your notes about this device
      * @param {String} [options.product]  Device in this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -553,7 +552,7 @@ class Particle {
      * @param {String} options.deviceId      Device ID or Name
      * @param {Boolean} options.development  Set to true to mark as development, false to return to product fleet
      * @param {String} options.product       Device in this product ID or slug
-     * @param {Auth}   [options.auth]        The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]        The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]     Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]     Request context
      * @returns {Promise} A promise
@@ -569,7 +568,7 @@ class Particle {
      * @param {Number}  options.desiredFirmwareVersion  Lock the product device to run this firmware version.
      * @param {Boolean} [options.flash]                 Immediately flash firmware indicated by desiredFirmwareVersion
      * @param {String}  options.product                 Device in this product ID or slug
-     * @param {Auth}    [options.auth]                  The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string}  [options.auth]                  The access token. Can be ignored if provided in constructor
      * @param {Object}  [options.headers]               Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object}  [options.context]               Request context
      * @returns {Promise} A promise
@@ -583,7 +582,7 @@ class Particle {
      * @param {Object} options            Options for this API call
      * @param {String} options.deviceId   Device ID or Name
      * @param {String} options.product    Device in this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -604,7 +603,7 @@ class Particle {
      *                                                          Pass `null` to unlock firmware and go back to released firmware.
      * @param {Boolean}       [options.flash]                   (Product only) Immediately flash firmware indicated by desiredFirmwareVersion
      * @param {String}        [options.product]                 Device in this product ID or slug
-     * @param {Auth}          [options.auth]                    The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string}        [options.auth]                    The access token. Can be ignored if provided in constructor
      * @param {Object}        [options.headers]                 Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object}        [options.context]                 Request context
      * @returns {Promise} A promise
@@ -636,7 +635,7 @@ class Particle {
      * @param {String} [options.deviceSignature] Base64-encoded device signature. Mandatory if `action` is `confirm`,
      * @param {String} [options.devicePublicKeyFingerprint] Base64-encoded fingerprint of the device public key.
      *                                           Mandatory if `action` is `confirm`,
-     * @param {Auth}   [options.auth]            Access token or basic auth object. Can be ignored if provided in constructor.
+     * @param {string} [options.auth]            The access token. Can be ignored if provided in constructor.
      * @param {Object} [options.headers]         Key/value pairs to send as headers.
      * @param {Object} [options.context]         Request context.
      * @returns {Promise} A promise
@@ -663,7 +662,7 @@ class Particle {
      * Provision a new device for products that allow self-provisioning
      * @param {Object} options            Options for this API call
      * @param {String} options.productId  Product ID where to create this device
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -685,7 +684,7 @@ class Particle {
      * @param {Object} options            Options for this API call
      * @param {String} [options.iccid]    ICCID of the SIM card used in the Electron
      * @param {String} [options.product]  Device in this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -710,7 +709,7 @@ class Particle {
      * @param {String} options.deviceId   Device ID or Name
      * @param {String} options.name       Variable name
      * @param {String} [options.product]  Device in this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -730,7 +729,7 @@ class Particle {
      * @param {String} options.product                 Flash device in this product ID or slug
      * @param {Object} options.files                   Object containing files to be compiled and flashed. Keys should be the filenames, including relative path, and the values should be a path or Buffer of the file contents in Node, or a File or Blob in the browser.
      * @param {String} [options.targetVersion=latest]  System firmware version to compile against
-     * @param {Auth}   [options.auth]                  The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]                  The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]               Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]               Request context
      * @returns {Promise} A promise
@@ -752,7 +751,7 @@ class Particle {
      * DEPRECATED: Flash the Tinker application to a device. Instead compile and flash the Tinker source code.
      * @param {Object} options            Options for this API call
      * @param {String} options.deviceId   Device ID or Name
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -780,7 +779,7 @@ class Particle {
      * @param {Object} options.files                   Object containing files to be compiled. Keys should be the filenames, including relative path, and the values should be a path or Buffer of the file contents in Node, or a File or Blob in the browser.
      * @param {Number} [options.platformId]            Platform id number of the device you are compiling for. Common values are 0=Core, 6=Photon, 10=Electron.
      * @param {String} [options.targetVersion=latest]  System firmware version to compile against
-     * @param {Auth}   [options.auth]                  The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]                  The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]               Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]               Request context
      * @returns {Promise} A promise
@@ -809,7 +808,7 @@ class Particle {
      * Download a firmware binary
      * @param {Object} options            Options for this API call
      * @param {String} options.binaryId   Binary ID received from a successful compile call
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise<RequestResponse, RequestError>} A promise
@@ -831,7 +830,7 @@ class Particle {
      * @param {String}          options.deviceId         Device ID or Name
      * @param {String | Buffer} options.key              Public key contents
      * @param {String}          [options.algorithm=rsa]  Algorithm used to generate the public key. Valid values are `rsa` or `ecc`.
-     * @param {Auth}            [options.auth]           The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string}          [options.auth]           The access token. Can be ignored if provided in constructor
      * @param {Object}          [options.headers]        Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object}          [options.context]        Request context
      * @returns {Promise} A promise
@@ -859,7 +858,7 @@ class Particle {
      * @param {String} options.name       Function name
      * @param {String} options.argument   Function argument
      * @param {String} [options.product]  Device in this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -878,7 +877,7 @@ class Particle {
      * @param {String} [options.name]      Event Name
      * @param {String} [options.org]       Organization Slug
      * @param {String} [options.product]   Events for this product ID or slug
-     * @param {Auth}   [options.auth]      The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]      The access token. Can be ignored if provided in constructor
      * @returns {Promise} If the promise resolves, the resolution value will be an EventStream object that will
      * emit 'event' events.
      */
@@ -916,7 +915,7 @@ class Particle {
      * @param {String}  options.data       Event data
      * @param {Boolean} options.isPrivate  Should the event be publicly available?
      * @param {String}  [options.product]  Event for this product ID or slug
-     * @param {Auth}    [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string}  [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object}  [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object}  [options.context]  Request context
      * @returns {Promise} A promise
@@ -930,7 +929,7 @@ class Particle {
     /**
      * @typedef  {Object}  Hook
      * @property {String}  [method=POST]         Type of web request triggered by the Webhook (GET, POST, PUT, or DELETE)
-     * @property {Object}  [auth]                Auth data like `{ username: 'me', password: '1234' }` to send via basic auth header with the Webhook request
+     * @property {Object}  [auth]                Auth data like `{ user: 'me', pass: '1234' }` for basic auth or `{ bearer: 'token' }` to send with the Webhook request
      * @property {Object}  [headers]             Additional headers to add to the Webhook like `{ 'X-ONE': '1', X-TWO: '2' }`
      * @property {Object}  [query]               Query params to add to the Webhook request like `{ foo: 'foo', bar: 'bar' }`
      * @property {Object}  [json]                JSON data to send with the Webhook request - sets `Content-Type` to `application/json`
@@ -951,7 +950,7 @@ class Particle {
      * @param {Boolean} [options.noDefaults]          Don't include default event data in the webhook request
      * @param {Hook}    [options.hook]                Webhook configuration settings
      * @param {String}  [options.product]             Webhook for this product ID or slug
-     * @param {Auth}    [options.auth]                The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string}  [options.auth]                The access token. Can be ignored if provided in constructor
      * @param {Object}  [options.headers]             Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object}  [options.context]             Request context
      * @returns {Promise} A promise
@@ -985,7 +984,7 @@ class Particle {
      * @param {Object} options            Options for this API call
      * @param {String} options.hookId     Webhook ID
      * @param {String} [options.product]  Webhook for this product ID or slug
-     * @param {Auth}   [options.auth] The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth] The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -999,7 +998,7 @@ class Particle {
      * List all webhooks owned by the account or product
      * @param {Object} options            Options for this API call
      * @param {String} [options.product]  Webhooks for this product ID or slug
-     * @param {Auth}   [options.auth] The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth] The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1019,7 +1018,7 @@ class Particle {
      * @param {Object} options.settings    Settings specific to that integration type
      * @param {String} [options.deviceId]  Trigger integration only for this device ID or Name
      * @param {String} [options.product]   Integration for this product ID or slug
-     * @param {Auth}   [options.auth]      The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]      The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]   Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]   Request context
      * @returns {Promise} A promise
@@ -1041,7 +1040,7 @@ class Particle {
      * @param {Object} [options.settings]     Change the settings specific to that integration type
      * @param {String} [options.deviceId]     Trigger integration only for this device ID or Name
      * @param {String} [options.product]      Integration for this product ID or slug
-     * @param {Auth}   [options.auth]         The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]         The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]      Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]      Request context
      * @returns {Promise} A promise
@@ -1058,7 +1057,7 @@ class Particle {
      * @param {Object} options                Options for this API call
      * @param {String} options.integrationId  The integration to remove
      * @param {String} [options.product]      Integration for this product ID or slug
-     * @param {Auth}   [options.auth]         The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]         The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]      Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]      Request context
      * @returns {Promise} A promise
@@ -1072,7 +1071,7 @@ class Particle {
      * List all integrations owned by the account or product
      * @param {Object} options            Options for this API call
      * @param {String} [options.product]  Integrations for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1085,7 +1084,7 @@ class Particle {
     /**
      * Get details about the current user
      * @param {Object} options            Options for this API call
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1097,7 +1096,7 @@ class Particle {
     /**
      * Set details on the current user
      * @param {Object} options              Options for this API call
-     * @param {Auth}   [options.auth]       The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]       The access token. Can be ignored if provided in constructor
      * @param {String} options.accountInfo  Set user's extended info fields (name, business account, company name, etc)
      * @param {Object} [options.headers]    Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]    Request context
@@ -1111,7 +1110,7 @@ class Particle {
     /**
      * Change username (i.e, email)
      * @param {Object}  options                   Options for this API call
-     * @param {Auth}    [options.auth]            The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string}  [options.auth]            The access token. Can be ignored if provided in constructor
      * @param {String}  options.currentPassword   Current password
      * @param {String}  options.username          New email
      * @param {Boolean} options.invalidateTokens  Should all tokens be invalidated
@@ -1132,7 +1131,7 @@ class Particle {
     /**
      * Change user's password
      * @param {Object}  options                   Options for this API call
-     * @param {Auth}    [options.auth]            The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string}  [options.auth]            The access token. Can be ignored if provided in constructor
      * @param {String}  options.currentPassword   Current password
      * @param {String}  options.password          New password
      * @param {Boolean} options.invalidateTokens  Should all tokens be invalidated
@@ -1159,7 +1158,7 @@ class Particle {
      * @param {Number} [options.page]        (Product only) Current page of results
      * @param {Number} [options.perPage]     (Product only) Records per page
      * @param {String} [options.product]     SIM cards for this product ID or slug
-     * @param {Auth}   [options.auth]        The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]        The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]     Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]     Request context
      * @returns {Promise} A promise
@@ -1175,7 +1174,7 @@ class Particle {
      * @param {Object} options            Options for this API call
      * @param {String} options.iccid      ICCID of the SIM card
      * @param {String} [options.product]  SIM card for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1192,7 +1191,7 @@ class Particle {
      * Get data usage for all SIM cards in a product the current billing period
      * @param {Object} options            Options for this API call
      * @param {String} options.product    SIM cards for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1210,7 +1209,7 @@ class Particle {
      * Check SIM status
      * @param {Object} options            Options for this API call
      * @param {String} options.iccid      ICCID of the SIM card
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1226,7 +1225,7 @@ class Particle {
      * @param {Array<String>} options.iccids       (Product only) ICCID of multiple SIM cards to import
      * @param {String}        options.country      The ISO country code for the SIM cards
      * @param {String}        [options.product]    SIM cards for this product ID or slug
-     * @param {Auth}          [options.auth]       The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string}        [options.auth]       The access token. Can be ignored if provided in constructor
      * @param {Object}        [options.headers]    Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object}        [options.context]    Request context
      * @param {any}           [options.promoCode]
@@ -1249,7 +1248,7 @@ class Particle {
      * @param {Object} options            Options for this API call
      * @param {String} options.iccid      ICCID of the SIM card
      * @param {String} [options.product]  SIM cards for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1266,7 +1265,7 @@ class Particle {
      * @param {String} options.iccid      ICCID of the SIM card
      * @param {Number} [options.mbLimit]  New monthly data limit. Necessary if unpausing a SIM card
      * @param {String} [options.product]  SIM cards for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1283,7 +1282,7 @@ class Particle {
      * @param {String} options.iccid      ICCID of the SIM card
      * @param {Array}  options.mbLimit    Data limit in megabyte for the SIM card
      * @param {String} [options.product]  SIM cards for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1299,7 +1298,7 @@ class Particle {
      * @param {Object} options            Options for this API call
      * @param {String} options.iccid      ICCID of the SIM card
      * @param {String} [options.product]  SIM cards for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1313,7 +1312,7 @@ class Particle {
      * List valid build targets to be used for compiling
      * @param {Object}  options                       Options for this API call
      * @param {Boolean} [options.onlyFeatured=false]  Only list featured build targets
-     * @param {Auth}    [options.auth]                The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string}  [options.auth]                The access token. Can be ignored if provided in constructor
      * @param {Object}  [options.headers]             Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object}  [options.context]             Request context
      * @returns {Promise} A promise
@@ -1342,7 +1341,7 @@ class Particle {
      *                                                - 'featured' - list only featured libraries
      * @param {String}         options.excludeScopes  list of scopes to exclude
      * @param {String}         options.category       Category to filter
-     * @param {Auth}           [options.auth]         The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string}         [options.auth]         The access token. Can be ignored if provided in constructor
      * @param {Object}         [options.headers]      Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object}         [options.context]      Request context
      * @returns {Promise} A promise
@@ -1375,7 +1374,7 @@ class Particle {
      * @param {Object} options            Options for this API call
      * @param {String} options.name       Name of the library to fetch
      * @param {String} options.version    Version of the library to fetch (default: latest)
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1396,7 +1395,7 @@ class Particle {
      * @param {String} options.name       Name of the library to fetch
      * @param {Number} options.page       Page index (default, first page)
      * @param {Number} options.limit      Number of items per page
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1416,7 +1415,7 @@ class Particle {
      * @param {Object}          options            Options for this API call
      * @param {String | Buffer} options.archive    Compressed archive file containing the library sources
      *                                             Either a path or Buffer of the file contents in Node, or a File or Blob in the browser.
-     * @param {Auth}            [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string}          [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object}          [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object}          [options.context]  Request context
      * @returns {Promise} A promise
@@ -1440,7 +1439,7 @@ class Particle {
      * Publish the latest version of a library to the public
      * @param {Object} options            Options for this API call
      * @param {String} options.name       Name of the library to publish
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1461,7 +1460,7 @@ class Particle {
      * @param {Object} options            Options for this API call
      * @param {String} options.name       Name of the library to remove
      * @param {String} options.force      Key to force deleting a public library
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1492,7 +1491,7 @@ class Particle {
      * List OAuth client created by the account
      * @param {Object} options            Options for this API call
      * @param {String} [options.product]  List clients for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1510,7 +1509,7 @@ class Particle {
      * @param {String} [options.redirect_uri]  URL to redirect after OAuth flow. Only for type web.
      * @param {Object} [options.scope]         Limits what the access tokens created by this client can do.
      * @param {String} [options.product]       Create client for this product ID or slug
-     * @param {Auth}   [options.auth]          The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]          The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]       Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]       Request context
      * @returns {Promise} A promise
@@ -1528,7 +1527,7 @@ class Particle {
      * @param {String} [options.name]     New Name of the OAuth client
      * @param {Object} [options.scope]    New scope of the OAuth client
      * @param {String} [options.product]  Update client linked to this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1544,7 +1543,7 @@ class Particle {
      * @param {Object} options            Options for this API call
      * @param {String} options.clientId   The OAuth client to update
      * @param {String} [options.product]  OAuth client linked to this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1557,7 +1556,7 @@ class Particle {
     /**
      * List products the account has access to
      * @param {Object} options            Options for this API call
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1570,7 +1569,7 @@ class Particle {
      * Get detailed information about a product
      * @param {Object} options            Options for this API call
      * @param {String} options.product    Product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1583,7 +1582,7 @@ class Particle {
      * List product firmware versions
      * @param {Object} options            Options for this API call
      * @param {String} options.product    Firmware for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1601,7 +1600,7 @@ class Particle {
      * @param {String} options.title          Short identifier for the new firmware
      * @param {String} [options.description]  Longer description for the new firmware
      * @param {String} options.product        Firmware for this product ID or slug
-     * @param {Auth}   [options.auth]         The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]         The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]      Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]      Request context
      * @returns {Promise} A promise
@@ -1629,7 +1628,7 @@ class Particle {
      * @param {Object} options            Options for this API call
      * @param {Number} options.version    Version number of firmware
      * @param {String} options.product    Firmware for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1650,7 +1649,7 @@ class Particle {
      * @param {String} [options.title]        New title
      * @param {String} [options.description]  New description
      * @param {String} options.product        Firmware for this product ID or slug
-     * @param {Auth}   [options.auth]         The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]         The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]      Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]      Request context
      * @returns {Promise} A promise
@@ -1665,7 +1664,7 @@ class Particle {
      * @param {Object} options            Options for this API call
      * @param {Number} options.version    Version number of new firmware
      * @param {String} options.product    Firmware for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise<RequestResponse, RequestError>} A promise that resolves with either the requested data or an error object
@@ -1686,7 +1685,7 @@ class Particle {
      * @param {Object} options            Options for this API call
      * @param {Number} options.version    Version number of new firmware
      * @param {String} options.product    Firmware for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1700,7 +1699,7 @@ class Particle {
      * List product team members
      * @param {Object} options            Options for this API call
      * @param {String} options.product    Team for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1719,7 +1718,7 @@ class Particle {
      * @param {Object} options            Options for this API call
      * @param {String} options.username   Username for the Particle account
      * @param {String} options.product    Team for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1739,7 +1738,7 @@ class Particle {
      * @param {Object} options            Options for this API call
      * @param {String} options.username   Username for the Particle account
      * @param {String} options.product    Team for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1757,7 +1756,7 @@ class Particle {
      * Fetch details about a serial number
      * @param {Object} options               Options for this API call
      * @param {String} options.serialNumber  The serial number printed on the barcode of the device packaging
-     * @param {Auth}   [options.auth]        The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]        The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]     Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]     Request context
      * @returns {Promise} A promise
@@ -1777,7 +1776,7 @@ class Particle {
      * @param {String} options.name       Network name
      * @param {String} options.deviceId   Gateway device ID
      * @param {String} [options.iccid]    ICCID of the active SIM card (only for cellular gateway devices)
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise<Object>} A promise
@@ -1796,7 +1795,7 @@ class Particle {
      * Remove a mesh network.
      * @param {Object} options            Options for this API call
      * @param {String} options.networkId  Network ID or name
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise<Object>} A promise
@@ -1808,7 +1807,7 @@ class Particle {
     /**
      * List all mesh networks
      * @param {Object} options            Options for this API call
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Number} [options.page]     Current page of results
      * @param {Number} [options.perPage]  Records per page
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
@@ -1824,7 +1823,7 @@ class Particle {
      * Get information about a mesh network.
      * @param {Object} options            Options for this API call
      * @param {String} options.networkId  Network ID or name
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise<Object>} A promise
@@ -1839,7 +1838,7 @@ class Particle {
      * @param {String} options.networkId  Network ID or name
      * @param {String} options.action     'add-device', 'remove-device', 'gateway-enable' or 'gateway-disable'
      * @param {String} options.deviceId   Device ID
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise<Object>} A promise
@@ -1859,7 +1858,7 @@ class Particle {
      * @param {Object} options            Options for this API call
      * @param {String} options.networkId  Network ID or name
      * @param {String} options.deviceId   Device ID
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise<Object>} A promise
@@ -1880,7 +1879,7 @@ class Particle {
      * @param {Object} options              Options for this API call
      * @param {String} [options.networkId]  Network ID or name
      * @param {String} options.deviceId     Device ID
-     * @param {Auth}   [options.auth]       The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]       The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]    Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]    Request context
      * @returns {Promise<Object>} A promise
@@ -1907,7 +1906,7 @@ class Particle {
      * List all devices of a mesh network.
      * @param {Object} options            Options for this API call
      * @param {String} options.networkId  Network ID or name
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Number} [options.role]     Device role: 'gateway' or 'node'
      * @param {Number} [options.page]     Current page of results
      * @param {Number} [options.perPage]  Records per page
@@ -1930,7 +1929,7 @@ class Particle {
      * Get product configuration
      * @param {Object} options            Options for this API call
      * @param {String} options.product    Config for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1948,7 +1947,7 @@ class Particle {
      * Get product configuration schema
      * @param {Object} options            Options for this API call
      * @param {String} options.product    Config for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
      * @returns {Promise} A promise
@@ -1967,7 +1966,7 @@ class Particle {
      * Get product device's configuration
      * @param {Object} options            Options for this API call
      * @param {String} options.product    Config for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {String} options.deviceId   Device ID to access
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
@@ -1986,7 +1985,7 @@ class Particle {
      * Get product device's configuration schema
      * @param {Object} options            Options for this API call
      * @param {String} options.product    Config for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {String} options.deviceId   Device ID to access
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
@@ -2006,7 +2005,7 @@ class Particle {
      * Set product configuration
      * @param {Object} options            Options for this API call
      * @param {String} options.product    Config for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} options.config     Product configuration to update
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]  Request context
@@ -2026,7 +2025,7 @@ class Particle {
      * Set product configuration for a specific device within the product
      * @param {Object} options            Options for this API call
      * @param {String} options.product    Config for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {Object} options.config     Product configuration to update
      * @param {String} options.deviceId   Device ID to access
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
@@ -2047,7 +2046,7 @@ class Particle {
      * Query location for devices within a product
      * @param {Object} options             Options for this API call
      * @param {String} options.product     Locations for this product ID or slug
-     * @param {Auth}   [options.auth]      The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]      The access token. Can be ignored if provided in constructor
      * @param {String} options.dateRange   Start and end date in ISO8601 format, separated by comma, to query
      * @param {String} options.rectBl      Bottom left of the rectangular bounding box to query. Latitude and longitude separated by comma
      * @param {String} options.rectTr      Top right of the rectangular bounding box to query. Latitude and longitude separated by comma
@@ -2083,7 +2082,7 @@ class Particle {
      * Query location for one device within a product
      * @param {Object} options            Options for this API call
      * @param {String} options.product    Locations for this product ID or slug
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {String} options.dateRange  Start and end date in ISO8601 format, separated by comma, to query
      * @param {String} options.rectBl     Bottom left of the rectangular bounding box to query. Latitude and longitude separated by comma
      * @param {String} options.rectTr     Top right of the rectangular bounding box to query. Latitude and longitude separated by comma
@@ -2114,7 +2113,7 @@ class Particle {
      * NOTE: Any external interactions such as Particle.publish will actually occur when the logic is executed.
      *
      * @param {Object} options            The options for creating the logic function.
-     * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor
      * @param {string} [options.org]      The Organization ID or slug. If not provided, the request will go to your sandbox account.
      * @param {Object} options.logic      The logic "function" which will be executed once
      * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
@@ -2142,7 +2141,7 @@ class Particle {
      * according to the cron and start_at properties.
      *
      * @param {Object} options                The options for creating the logic function.
-     * @param {Auth}   [options.auth]         The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]         The access token. Can be ignored if provided in constructor
      * @param {string} [options.org]          The Organization ID or slug. If not provided, the request will go to your sandbox account.
      * @param {Object} options.logicFunction  The logic function object containing the function details.
      * @param {Object} [options.headers]      Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
@@ -2164,7 +2163,7 @@ class Particle {
      * Get a logic function in the specified organization or sandbox by logic function ID.
      *
      * @param {Object} options                 The options for the logic function.
-     * @param {Auth}   [options.auth]          The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]          The access token. Can be ignored if provided in constructor
      * @param {string} [options.org]           The Organization ID or slug. If not provided, the request will go to your sandbox account.
      * @param {string} options.logicFunctionId The ID of the logic function to retrieve.
      * @param {Object} [options.headers]       Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
@@ -2187,7 +2186,7 @@ class Particle {
      * If you include an id on a logic trigger, it will update the logic trigger in place.
      *
      * @param {Object} options                  The options for updating the logic function.
-     * @param {Auth}   [options.auth]           The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]           The access token. Can be ignored if provided in constructor
      * @param {string} [options.org]            The Organization ID or slug. If not provided, the request will go to your sandbox account.
      * @param {string} options.logicFunctionId  The ID of the logic function to update.
      * @param {Object} options.logicFunction    The logic function object containing the logic function details.
@@ -2210,7 +2209,7 @@ class Particle {
      * Deletes a logic function in the specified organization or sandbox by logic function ID.
      *
      * @param {Object} options                  The options for deleting the logic function.
-     * @param {Auth}   [options.auth]           The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]           The access token. Can be ignored if provided in constructor
      * @param {string} [options.org]            The Organization ID or slug. If not provided, the request will go to your sandbox account.
      * @param {string} options.logicFunctionId  The ID of the logic function to delete.
      * @param {Object} [options.headers]        Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
@@ -2231,7 +2230,7 @@ class Particle {
      * Lists all logic functions in the specified organization or sandbox.
      *
      * @param {Object}  options               The options for listing logic functions.
-     * @param {Auth}    [options.auth]        The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string}  [options.auth]        The access token. Can be ignored if provided in constructor
      * @param {string}  [options.org]         The Organization ID or slug. If not provided, the request will go to your sandbox account.
      * @param {boolean} [options.todayStats]  Whether to include today's stats in the response
      * @param {Object}  [options.headers]     Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
@@ -2255,7 +2254,7 @@ class Particle {
      * Lists all logic runs for the specified logic function in the specified organization or sandbox.
      *
      * @param {Object} options                  The options for the request.
-     * @param {Auth}   [options.auth]           The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]           The access token. Can be ignored if provided in constructor
      * @param {string} [options.org]            The Organization ID or slug. If not provided, the request will go to your sandbox account.
      * @param {string} options.logicFunctionId  The ID of the logic function for which to retrieve the logic runs.
      * @param {Object} [options.headers]        Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
@@ -2276,7 +2275,7 @@ class Particle {
      * Retrieves a logic run by its ID for the specified logic function in the specified organization or sandbox.
      *
      * @param {Object} options                  The options for the request.
-     * @param {Auth}   [options.auth]           The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]           The access token. Can be ignored if provided in constructor
      * @param {string} [options.org]            The Organization ID or slug. If not provided, the request will go to your sandbox account.
      * @param {string} options.logicFunctionId  The ID of the logic function for which to retrieve the logic run.
      * @param {string} options.logicRunId       The ID of the logic run to retrieve.
@@ -2298,7 +2297,7 @@ class Particle {
      * Retrieves the logs for a logic run by its ID for the specified logic function in the specified organization or sandbox.
      *
      * @param {Object} options                  The options for the request.
-     * @param {Auth}   [options.auth]           The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]           The access token. Can be ignored if provided in constructor
      * @param {string} [options.org]            The unique identifier of the organization.
      * @param {string} options.logicFunctionId  The ID of the logic function for which to retrieve the logic run logs.
      * @param {string} options.logicRunId       The ID of the logic run for which to retrieve the logs.
@@ -2320,7 +2319,7 @@ class Particle {
      * Creates a new ledger definition in the specified organization or sandbox.
      *
      * @param {Object} options              The options for creating the ledger definition.
-     * @param {Auth}   [options.auth]       The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]       The access token. Can be ignored if provided in constructor
      * @param {string} [options.org]        The Organization ID or slug. If not provided, the request will go to your sandbox account.
      * @param {object} options.ledger       The ledger definition object.
      * @param {Object} [options.headers]    Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
@@ -2342,7 +2341,7 @@ class Particle {
      * Get a ledger definition in the specified organization or sandbox by ledger name.
      *
      * @param {Object} options             The options for the ledger definition.
-     * @param {Auth}   [options.auth]      The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]      The access token. Can be ignored if provided in constructor
      * @param {string} [options.org]       The Organization ID or slug. If not provided, the request will go to your sandbox account.
      * @param {string} options.ledgerName  The ID of the ledger definition to retrieve.
      * @param {Object} [options.headers]   Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
@@ -2363,7 +2362,7 @@ class Particle {
      * Updates an existing ledger definition in the specified organization or sandbox.
      *
      * @param {Object} options             The options for updating the ledger definition.
-     * @param {Auth}   [options.auth]      The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]      The access token. Can be ignored if provided in constructor
      * @param {string} [options.org]       The Organization ID or slug. If not provided, the request will go to your sandbox account.
      * @param {string} options.ledgerName  Name of the ledger definition to update.
      * @param {object} options.ledger      The ledger definition object.
@@ -2386,7 +2385,7 @@ class Particle {
      * Archives a ledger definition in the specified organization or sandbox by ledger name.
      *
      * @param {Object} options             The options for archiving the ledger definition.
-     * @param {Auth}   [options.auth]      The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]      The access token. Can be ignored if provided in constructor
      * @param {string} [options.org]       The Organization ID or slug. If not provided, the request will go to your sandbox account.
      * @param {string} options.ledgerName  Name of the ledger definition to archive.
      * @param {Object} [options.headers]   Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
@@ -2411,7 +2410,7 @@ class Particle {
      * Lists all ledger definitions in the specified organization or sandbox.
      *
      * @param {Object}  options             The options for listing ledger definitions.
-     * @param {Auth}    [options.auth]      The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string}  [options.auth]      The access token. Can be ignored if provided in constructor
      * @param {string}  [options.org]       The Organization ID or slug. If not provided, the request will go to your sandbox account.
      * @param {Scope}   [options.scope]     Filter to show only ledgers of the specified scope
      * @param {boolean} [options.archived]  Filter to show only archived ledger or non-archived ledgers. If not provided, all ledgers are returned.
@@ -2441,7 +2440,7 @@ class Particle {
      * Get ledger instance data.
      *
      * @param {Object} options             The options for the ledger instance.
-     * @param {Auth}   [options.auth]      The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]      The access token. Can be ignored if provided in constructor
      * @param {string} [options.org]       The Organization ID or slug. If not provided, the request will go to your sandbox account.
      * @param {string} options.ledgerName  Ledger name.
      * @param {string} options.scopeValue  Scope value.
@@ -2467,7 +2466,7 @@ class Particle {
      * Set ledger instance data.
      *
      * @param {Object}  options             The options for updating the ledger instance.
-     * @param {Auth}    [options.auth]      The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string}  [options.auth]      The access token. Can be ignored if provided in constructor
      * @param {string}  [options.org]       The Organization ID or slug. If not provided, the request will go to your sandbox account.
      * @param {string}  options.ledgerName  Ledger name.
      * @param {string}  options.scopeValue  Scope value.
@@ -2495,7 +2494,7 @@ class Particle {
      * Delete a ledger instance in the specified organization or sandbox by ledger name.
      *
      * @param {Object} options             The options for archiving the ledger instance.
-     * @param {Auth}   [options.auth]      The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]      The access token. Can be ignored if provided in constructor
      * @param {string} [options.org]       The Organization ID or slug. If not provided, the request will go to your sandbox account.
      * @param {string} options.ledgerName  Name of the ledger instance to archive.
      * @param {string} options.scopeValue  Scope value.
@@ -2517,7 +2516,7 @@ class Particle {
      * Lists ledger instances in the specified organization or sandbox.
      *
      * @param {Object} options             The options for listing ledger instances.
-     * @param {Auth}   [options.auth]      The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]      The access token. Can be ignored if provided in constructor
      * @param {string} [options.org]       The unique identifier of the organization.
      * @param {string} options.ledgerName  Name of the ledger instance to archive.
      * @param {number} [options.page]      Page of results to display
@@ -2544,7 +2543,7 @@ class Particle {
      * List ledger instance versions
      *
      * @param {Object} options                   The options for the ledger instance.
-     * @param {Auth}   [options.auth]            The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]            The access token. Can be ignored if provided in constructor
      * @param {string} [options.org]             The Organization ID or slug. If not provided, the request will go to your sandbox account.
      * @param {string} options.ledgerName        Ledger name.
      * @param {string} options.scopeValue        Scope value.
@@ -2572,7 +2571,7 @@ class Particle {
      * Get specific ledger instance version
      *
      * @param {Object} options             The options for the ledger instance.
-     * @param {Auth}   [options.auth]      The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]      The access token. Can be ignored if provided in constructor
      * @param {string} [options.org]       The Organization ID or slug. If not provided, the request will go to your sandbox account.
      * @param {string} options.ledgerName  Ledger name.
      * @param {string} options.scopeValue  Scope value.
@@ -2599,7 +2598,7 @@ class Particle {
      * @param {Number} [options.internalVersion]  Internal version number to filter Device OS versions
      * @param {Number} [options.page]             Page number for pagination
      * @param {Number} [options.perPage]          Number of items per page
-     * @param {Auth}   [options.auth]             The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]             The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]          Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]          Request context
      *
@@ -2628,7 +2627,7 @@ class Particle {
      * @param {Object} options               Options for this API call
      * @param {String} options.version       Version of the Device OS
      * @param {Number} [options.platformId]  Optional platform ID to filter Device OS version
-     * @param {Auth}   [options.auth]        The access token or basic auth object. Can be ignored if provided in constructor
+     * @param {string} [options.auth]        The access token. Can be ignored if provided in constructor
      * @param {Object} [options.headers]     Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {Object} [options.context]     Request context
      *
@@ -2647,16 +2646,14 @@ class Particle {
 
     /**
      * Set default auth token that will be used in each method if `auth` is not provided
-     * @param {Auth} auth The access token or basic auth object
+     * @param {string} auth The access token
      * @throws {Error} When not auth string is provided
      */
     setDefaultAuth(auth){
         if (typeof auth === 'string' && auth.length !== 0) {
             this._defaultAuth = auth;
-        } else if (typeof auth === 'object' && 'username' in auth && 'password' in auth) {
-            this._defaultAuth = auth;
         } else {
-            throw new Error('Must pass a non-empty string or object with username and password for basic auth!');
+            throw new Error('Must pass a non-empty string representing an auth token!');
         }
     }
     /**
@@ -2702,7 +2699,7 @@ class Particle {
      * Make a GET request
      * @param {object} params
      * @param {string} params.uri        The URI to request
-     * @param {Auth}   [params.auth]     Authorization token to use
+     * @param {string} [params.auth]     Authorization token to use
      * @param {object} [params.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {object} [params.query]    Key/Value pairs of query params or a correctly formatted string
      * @param {object} [params.context]  The invocation context, describing the tool and project
@@ -2718,7 +2715,7 @@ class Particle {
      * Make a HEAD request
      * @param {object} params
      * @param {string} params.uri        The URI to request
-     * @param {Auth}   [params.auth]     Authorization token to use
+     * @param {string} [params.auth]     Authorization token to use
      * @param {object} [params.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {object} [params.query]    Key/Value pairs of query params or a correctly formatted string
      * @param {object} [params.context]  The invocation context, describing the tool and project
@@ -2734,7 +2731,7 @@ class Particle {
      * Make a POST request
      * @param {object}          params
      * @param {string}          params.uri        The URI to request
-     * @param {Auth}            [params.auth]     Authorization token to use
+     * @param {string}          [params.auth]     Authorization token to use
      * @param {object}          [params.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {string | object} [params.data]     Request body
      * @param {object}          [params.context]  The invocation context, describing the tool and project
@@ -2750,7 +2747,7 @@ class Particle {
      * Make a PUT request
      * @param {object}          params
      * @param {string}          params.uri        The URI to request
-     * @param {Auth}            [params.auth]     Authorization token to use
+     * @param {string}          [params.auth]     Authorization token to use
      * @param {object}          [params.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {string | object} [params.data]     Request body
      * @param {object}          [params.query]    Key/Value pairs of query params or a correctly formatted string
@@ -2767,7 +2764,7 @@ class Particle {
      * Make a DELETE request
      * @param {object}          params
      * @param {string}          params.uri        The URI to request
-     * @param {Auth}            [params.auth]     Authorization token to use
+     * @param {string}          [params.auth]     Authorization token to use
      * @param {object}          [params.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {string | object} [params.data]     Request body
      * @param {object}          [params.context]  The invocation context, describing the tool and project
@@ -2786,7 +2783,7 @@ class Particle {
      * @param {String}  args.method      The method used to request the URI, should be in uppercase.
      * @param {Object}  [args.headers]   Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
      * @param {object}  [args.data]      Arbitrary data to send as the body.
-     * @param {Auth}    [args.auth]      Authorization
+     * @param {string}  [args.auth]      Authorization
      * @param {Object}  [args.query]     Query parameters
      * @param {Object}  [args.form]      Form fields
      * @param {Object}  [args.files]     Array of file names and file content

--- a/src/Particle.js
+++ b/src/Particle.js
@@ -291,26 +291,6 @@ class Particle {
     }
 
     /**
-     * Revoke an access token
-     * @param {Object} options            Options for this API call
-     * @param {String} options.username   Username of the Particle cloud account that the token belongs to.
-     * @param {String} options.password   Password for the account
-     * @param {String} options.token      Access token you wish to revoke
-     * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
-     * @param {Object} [options.context]  Request context
-     * @returns {Promise} A promise
-     */
-    deleteAccessToken({ username, password, token, headers, context }){
-        return this.delete({
-            uri: `/v1/access_tokens/${token}`,
-            auth: { username, password },
-            headers,
-            data: { access_token: token },
-            context
-        });
-    }
-
-    /**
      * Revoke the current session access token
      * @param {Object} options            Options for this API call
      * @param {Auth}   [options.auth]     The access token or basic auth object. Can be ignored if provided in constructor
@@ -358,26 +338,6 @@ class Particle {
             uri: '/v1/user',
             data: { password },
             auth,
-            headers,
-            context
-        });
-    }
-
-    /**
-     * List all valid access tokens for a Particle Cloud account
-     * @param {Object} options            Options for this API call
-     * @param {String} options.username   Username
-     * @param {String} options.password   Password
-     * @param {String} options.otp        Current one-time-password generated from the authentication application
-     * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
-     * @param {Object} [options.context]  Request context
-     * @returns {Promise} A promise
-     */
-    listAccessTokens({ username, password, otp, headers, context }){
-        return this.get({
-            uri: '/v1/access_tokens',
-            auth: { username, password },
-            query: otp ? { otp } : undefined,
             headers,
             context
         });
@@ -2851,8 +2811,5 @@ class Particle {
         this.agent.setBaseUrl(baseUrl);
     }
 }
-
-// Aliases for backwards compatibility
-Particle.prototype.removeAccessToken = Particle.prototype.deleteAccessToken;
 
 module.exports = Particle;

--- a/test/Agent.spec.js
+++ b/test/Agent.spec.js
@@ -108,28 +108,6 @@ describe('Agent', () => {
             const headers = agent._getAuthorizationHeader(auth);
             expect(headers).to.eql({ Authorization: bearer });
         });
-
-        if (typeof window !== 'undefined') {
-            it('supports auth with user/pass in browsers', () => {
-                const auth = {
-                    username: 'test@particle.io',
-                    password: 'super_secret'
-                };
-                const basic = 'Basic dGVzdEBwYXJ0aWNsZS5pbzpzdXBlcl9zZWNyZXQ=';
-                const headers = agent._getAuthorizationHeader(auth);
-                expect(headers).to.eql({ Authorization: basic });
-            });
-        } else {
-            it('supports auth with user/pass in node', () => {
-                const auth = {
-                    username: 'test@particle.io',
-                    password: 'super_secret'
-                };
-                const basic = 'Basic dGVzdEBwYXJ0aWNsZS5pbzpzdXBlcl9zZWNyZXQ=';
-                const headers = agent._getAuthorizationHeader(auth);
-                expect(headers).to.eql({ Authorization: basic });
-            });
-        }
     });
 
     describe('request', () => {

--- a/test/Particle.spec.js
+++ b/test/Particle.spec.js
@@ -389,21 +389,6 @@ describe('ParticleAPI', () => {
             });
         });
 
-        describe('.deleteAccessToken', () => {
-            it('sends request', () => {
-                return api.deleteAccessToken(props).then((results) => {
-                    results.should.match({
-                        method: 'delete',
-                        uri: `/v1/access_tokens/${props.token}`,
-                        auth: {
-                            username: props.username,
-                            password: props.password
-                        }
-                    });
-                });
-            });
-        });
-
         describe('.deleteCurrentAccessToken', () => {
             it('sends request', () => {
                 return api.deleteCurrentAccessToken(props).then((results) => {
@@ -425,41 +410,6 @@ describe('ParticleAPI', () => {
                         auth: props.auth,
                     });
                 });
-            });
-        });
-
-        describe('.listAccessTokens', () => {
-            let options;
-
-            beforeEach(() => {
-                options = {
-                    username: props.username,
-                    password: props.password,
-                    otp: props.otp
-                };
-            });
-
-            it('sends credentials', () => {
-                delete options.otp;
-                return api.listAccessTokens(options)
-                    .then(({ auth, query }) => {
-                        expect(auth).to.be.an('object');
-                        expect(auth).to.have.property('username', options.username);
-                        expect(auth).to.have.property('password', options.password);
-                        expect(query).to.equal(undefined);
-                    });
-            });
-
-            it('includes otp when provided', () => {
-                return api.listAccessTokens(options)
-                    .then(({ auth, query }) => {
-                        expect(auth).to.be.an('object');
-                        expect(auth).to.have.property('username', options.username);
-                        expect(auth).to.have.property('password', options.password);
-                        expect(query).to.be.an('object');
-                        expect(query).to.have.property('otp', props.otp);
-                        expect(props.otp).to.be.a('string').with.lengthOf(6);
-                    });
             });
         });
 
@@ -2984,12 +2934,6 @@ describe('ParticleAPI', () => {
                     });
                 });
             });
-        });
-    });
-
-    describe('backwards-compatibility function aliases', () => {
-        it('maps removeAccessToken to deleteAccessToken', () => {
-            api.removeAccessToken.should.equal(api.deleteAccessToken);
         });
     });
 

--- a/test/Particle.spec.js
+++ b/test/Particle.spec.js
@@ -3155,7 +3155,7 @@ describe('ParticleAPI', () => {
                 error = e;
             }
             expect(error).to.be.an.instanceOf(Error);
-            expect(error.message).to.eql('Must pass a non-empty string or object with username and password for basic auth!');
+            expect(error.message).to.eql('Must pass a non-empty string representing an auth token!');
         });
     });
 


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/130912

* Remove support for basic auth from Agent
* Remove deleteAccessToken and listAccessToken APIs
* Remove tests that test the above removed features