### PR TITLE
feat: [sc-131002] Remove query access_token from particle-api-js

### DIFF
--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -29,7 +29,10 @@ class EventStream extends EventEmitter {
             const req = requestor.request({
                 hostname,
                 protocol,
-                path: `${path}?access_token=${this.token}`,
+                path,
+                headers: {
+                    'Authorization': `Bearer ${this.token}`
+                },
                 method: 'get',
                 // @ts-ignore
                 port: parseInt(port, 10) || (isSecure ? 443 : 80),

--- a/test/EventStream.spec.js
+++ b/test/EventStream.spec.js
@@ -49,7 +49,10 @@ describe('EventStream', () => {
                 expect(http.request).to.have.been.calledWith({
                     hostname: 'hostname',
                     protocol: 'http:',
-                    path: '/path?access_token=token',
+                    path: '/path',
+                    headers: {
+                        'Authorization': 'Bearer token'
+                    },
                     method: 'get',
                     port: 8080,
                     mode: 'prefer-streaming'


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/131002