### PR TITLE
feat: [sc-131073] Re-add deleteAccessToken endpoint, but without basic auth from particle-api-js

### DIFF
--- a/src/Particle.js
+++ b/src/Particle.js
@@ -290,6 +290,22 @@ class Particle {
     }
 
     /**
+     * Revoke an access token
+     * @param {Object} options            Options for this API call
+     * @param {String} options.token      Access token you wish to revoke
+     * @param {Object} [options.headers]  Key/Value pairs like `{ 'X-FOO': 'foo', X-BAR: 'bar' }` to send as headers.
+     * @param {Object} [options.context]  Request context
+     * @returns {Promise} A promise
+     */
+    deleteAccessToken({ token, headers, context }){
+        return this.delete({
+            uri: `/v1/access_tokens/${token}`,
+            headers,
+            context
+        });
+    }
+
+    /**
      * Revoke the current session access token
      * @param {Object} options            Options for this API call
      * @param {string} [options.auth]     The access token. Can be ignored if provided in constructor

--- a/test/Particle.spec.js
+++ b/test/Particle.spec.js
@@ -389,6 +389,17 @@ describe('ParticleAPI', () => {
             });
         });
 
+        describe('.deleteAccessToken', () => {
+            it('sends request', () => {
+                return api.deleteAccessToken(props).then((results) => {
+                    results.should.match({
+                        method: 'delete',
+                        uri: `/v1/access_tokens/${props.token}`,
+                    });
+                });
+            });
+        });
+
         describe('.deleteCurrentAccessToken', () => {
             it('sends request', () => {
                 return api.deleteCurrentAccessToken(props).then((results) => {


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/131073