### PR TITLE
fix: [sc-132018] Device events console page is not working in Firefox

### DIFF
--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -29,7 +29,8 @@ class EventStream extends EventEmitter {
             const req = requestor.request({
                 hostname,
                 protocol,
-                path,
+                // Firefox has issues making multiple fetch requests with the same parameters so add a nonce
+                path: `${path}?nonce=${performance.now()}`,
                 headers: {
                     'Authorization': `Bearer ${this.token}`
                 },

--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -26,11 +26,12 @@ class EventStream extends EventEmitter {
 
             const isSecure = protocol === 'https:';
             const requestor = isSecure ? https : http;
+            const nonce = global.performance ? global.performance.now() : 0;
             const req = requestor.request({
                 hostname,
                 protocol,
                 // Firefox has issues making multiple fetch requests with the same parameters so add a nonce
-                path: `${path}?nonce=${performance.now()}`,
+                path: `${path}?nonce=${nonce}`,
                 headers: {
                     'Authorization': `Bearer ${this.token}`
                 },

--- a/test/EventStream.spec.js
+++ b/test/EventStream.spec.js
@@ -49,7 +49,7 @@ describe('EventStream', () => {
                 expect(http.request).to.have.been.calledWith({
                     hostname: 'hostname',
                     protocol: 'http:',
-                    path: '/path',
+                    path: '/path?nonce=0',
                     headers: {
                         'Authorization': 'Bearer token'
                     },


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/132018

Firefox has an inexplicable behavior where doing multiple `fetch` calls to the same endpoint with the same parameters makes the second request stall. It doesn't resolve or reject. Chrome and Edge do not have this issue.

One workaround I found is to use a different path by passing a nonce. We can discuss in a broader team what might be going on but it's sufficient to fix the issue for now.

Steps to test:
```
const particle = new Particle();
particle.getEventStream({ deviceId: '250029001550483553353620', product: 8178, auth }).then(stream => {
    console.log('event stream 1 connected');
});
particle.getEventStream({ deviceId: '250029001550483553353620', product: 8178, auth }).then(stream => {
    console.log('event stream 2 connected');
});
```
Expect to see both log lines. In Chrome, this is the case. In Firefox, before the fix, only the first log is shown.