### PR TITLE
Rely on the LICENSE text at the top of the repo rather than license headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2014 Spark IO
+   Copyright 2025 Particle Industries, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/Agent.js
+++ b/src/Agent.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 const fetch = require('node-fetch');
 const FormData = require('form-data');
 const qs = require('qs');

--- a/test/Agent.integration.js
+++ b/test/Agent.integration.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 /**
  * Tests for real the Agent class using an external service.
  */


### PR DESCRIPTION
The license for this repo has Apache 2.0 since 20214, but there were some files with comment headers with different language. 

This PR completes the intent of the initial commit that the LICENSE file at the top of the repo should define the text of the license for all the files in the repo rather than some files having separate license headers.