### PR TITLE
fix: [sc-138766] Fix silent SSE stream failures in particle-api-js EventStream

### DIFF
--- a/src/EventStream.ts
+++ b/src/EventStream.ts
@@ -63,11 +63,8 @@ class EventStream extends EventEmitter {
 			// Override Node.js globalAgent socket timeout (5s since Node 19) with a longer
 			// timeout suitable for SSE connections. This prevents the agent's idle timeout
 			// from interfering with long-lived streams.
-			req.on('socket', (socket) => {
-				socket.setTimeout(30000);
-				socket.on('timeout', () => {
-					socket.destroy(new Error('SSE socket timeout (30s idle)'));
-				});
+			req.setTimeout(30000, () => {
+				req.destroy(new Error('SSE socket timeout (30s idle)'));
 			});
 
 			this.req = req;

--- a/src/EventStream.ts
+++ b/src/EventStream.ts
@@ -26,7 +26,7 @@ class EventStream extends EventEmitter {
 		this.token = token;
 		this.httpAgent = httpAgent;
 		this.reconnectInterval = 2000;
-		this.timeout = 13000;
+		this.timeout = 15000;
 		this.data = '';
 		this.buf = '';
 
@@ -59,6 +59,16 @@ class EventStream extends EventEmitter {
 				requestOptions.agent = this.httpAgent;
 			}
 			const req = requestor.request(requestOptions);
+
+			// Override Node.js globalAgent socket timeout (5s since Node 19) with a longer
+			// timeout suitable for SSE connections. This prevents the agent's idle timeout
+			// from interfering with long-lived streams.
+			req.on('socket', (socket) => {
+				socket.setTimeout(30000);
+				socket.on('timeout', () => {
+					socket.destroy(new Error('SSE socket timeout (30s idle)'));
+				});
+			});
 
 			this.req = req;
 
@@ -165,10 +175,10 @@ class EventStream extends EventEmitter {
 	}
 
 	private isOffline(): boolean {
-		if (typeof navigator === 'undefined' || Object.hasOwnProperty.call(navigator, 'onLine')) {
-			return false;
+		if (typeof navigator !== 'undefined' && typeof navigator.onLine === 'boolean') {
+			return !navigator.onLine;
 		}
-		return !navigator.onLine;
+		return false; // Not in a browser — assume online
 	}
 
 	private startIdleTimeout(): void {


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/138766

Fixes 3 issues that could lead to disconnected event streams on Node.js
* Since Node 19, there's a default HTTPS timeout of 5 seconds. Switch to 30 seconds for long lived SSE connection.
* Server sends a newline every 9-13 seconds so make the idle timeout 15 seconds (long enough to avoid spurrious reconnects but not too long that it leads to dropped events).
* Rework browser detection in isOffline to ensure Node.js is always marked as online.

Stress-tested by running 20 instances of particle-api-js overnight and ensuring there's are no silent failures.